### PR TITLE
⚡ Fix Koin lifecycle and RepositoryManager reload

### DIFF
--- a/api/src/main/kotlin/party/morino/mpm/api/domain/repository/RepositoryManager.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/domain/repository/RepositoryManager.kt
@@ -42,4 +42,10 @@ interface RepositoryManager {
      * @return リポジトリソースのリスト
      */
     fun getRepositorySources(): List<PluginRepositorySource>
+
+    /**
+     * 設定を再読み込みしてリポジトリソースを再構築する
+     * デフォルト実装は何もしない（後方互換性のため）
+     */
+    fun reload() {}
 }

--- a/paper/src/main/kotlin/party/morino/mpm/Mpm.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/Mpm.kt
@@ -124,6 +124,9 @@ open class Mpm :
         // Webhookリソースの解放（Koin未初期化時はスキップ）
         GlobalContext.getOrNull()?.get<WebhookNotifier>()?.shutdown()
 
+        // Koin DIコンテナを停止（リソースリーク防止）
+        GlobalContext.stopKoin()
+
         logger.info("mpm has been disabled!")
     }
 
@@ -179,8 +182,9 @@ open class Mpm :
                 single<UpdateScheduler> { UpdateSchedulerImpl() }
             }
 
-        // Koinの開始（すでに開始されている場合は何もしない）
-        GlobalContext.getOrNull() ?: GlobalContext.startKoin {
+        // 既存のKoinコンテキストが残っている場合は停止してから再起動
+        GlobalContext.stopKoin()
+        GlobalContext.startKoin {
             modules(appModule)
         }
     }

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/repository/RepositoryManagerImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/repository/RepositoryManagerImpl.kt
@@ -18,7 +18,8 @@ import party.morino.mpm.api.domain.repository.RepositoryManager
  * 複数のリポジトリソースを優先順位順に管理する
  */
 class RepositoryManagerImpl(
-    private val sources: List<PluginRepositorySource>
+    private var sources: List<PluginRepositorySource>,
+    private val sourceFactory: (() -> List<PluginRepositorySource>)? = null
 ) : RepositoryManager {
     // キャッシュ用のプロパティ
     private var cachedPlugins: List<String>? = null
@@ -109,4 +110,16 @@ class RepositoryManagerImpl(
                 false
             }
         }
+
+    /**
+     * リポジトリソースを再構築し、キャッシュをクリアする
+     */
+    override fun reload() {
+        sourceFactory?.let { factory ->
+            sources = factory()
+        }
+        // キャッシュをクリア
+        cachedPlugins = null
+        cacheExpirationTime = 0
+    }
 }

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/repository/RepositorySourceManagerFactory.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/repository/RepositorySourceManagerFactory.kt
@@ -36,8 +36,14 @@ object RepositorySourceManagerFactory {
         val config = configManager.getConfig()
         val repositoryConfigs = config.repositories
 
+        // リポジトリソースを生成するファクトリーラムダ（reload時に再利用）
+        val sourceFactory = {
+            val currentConfig = configManager.getConfig()
+            RepositorySourceFactory.createAll(currentConfig.repositories, rootDir)
+        }
+
         // リポジトリソースのリストを生成してマネージャーを作成
-        val sources = RepositorySourceFactory.createAll(repositoryConfigs, rootDir)
-        return RepositoryManagerImpl(sources)
+        val sources = sourceFactory()
+        return RepositoryManagerImpl(sources, sourceFactory)
     }
 }

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/ReloadCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/ReloadCommand.kt
@@ -14,6 +14,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import party.morino.mpm.api.application.scheduler.UpdateScheduler
 import party.morino.mpm.api.domain.config.ConfigManager
+import party.morino.mpm.api.domain.repository.RepositoryManager
 import revxrsal.commands.annotation.Command
 import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.bukkit.annotation.CommandPermission
@@ -22,11 +23,14 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
 @CommandPermission("mpm.command")
 class ReloadCommand : KoinComponent {
     private val configManager: ConfigManager by inject()
+    private val repositoryManager: RepositoryManager by inject()
     private val updateScheduler: UpdateScheduler by inject()
 
     @Subcommand("reload")
     suspend fun reload(sender: CommandSender) {
         configManager.reload()
+        // リポジトリマネージャーを再構築して新しいリポジトリ設定を反映
+        repositoryManager.reload()
         // スケジューラーを再起動して新しい設定を反映
         updateScheduler.restart()
         sender.sendRichMessage("<green>設定ファイルを再読み込みしました。")


### PR DESCRIPTION
## Summary
- **Issue 1**: `onDisable()` now calls `stopKoin()` to properly clean up DI container resources. `setupKoin()` stops any existing Koin context before starting fresh.
- **Issue 2**: `RepositoryManager` gains `reload()` method. `RepositoryManagerImpl` uses a factory lambda to recreate sources from fresh config on reload. `ReloadCommand` calls `repositoryManager.reload()`.

## Test plan
- [ ] Verify plugin reload (`/mpm reload`) properly recreates repository sources
- [ ] Verify plugin disable/enable cycle doesn't leak Koin singletons
- [ ] Verify repository config changes take effect after `/mpm reload`

Closes #235