### PR TITLE
🔒 Use SafeConstructor for YAML parsing and add fine-grained permissions

### DIFF
--- a/paper/src/main/kotlin/party/morino/mpm/Mpm.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/Mpm.kt
@@ -102,6 +102,9 @@ open class Mpm :
             _configManager.reload()
         }
 
+        // パーミッション階層の登録（mpm.commandが全子パーミッションを含む）
+        registerPermissions()
+
         // Lampコマンドハンドラーの初期化
         setupCommandHandler()
 
@@ -128,6 +131,34 @@ open class Mpm :
         GlobalContext.stopKoin()
 
         logger.info("mpm has been disabled!")
+    }
+
+    /**
+     * パーミッション階層の登録
+     * mpm.commandが全子パーミッションを含むように設定する（後方互換性）
+     */
+    private fun registerPermissions() {
+        val childPermissions = listOf(
+            "mpm.command.add",
+            "mpm.command.remove",
+            "mpm.command.install",
+            "mpm.command.uninstall",
+            "mpm.command.update",
+            "mpm.command.list",
+            "mpm.command.backup",
+            "mpm.command.lock",
+            "mpm.command.init",
+            "mpm.command.reload"
+        )
+        // 子パーミッションを登録
+        val children = childPermissions.associateWith { true }
+        val parentPermission = org.bukkit.permissions.Permission(
+            "mpm.command",
+            "All mpm commands",
+            org.bukkit.permissions.PermissionDefault.OP,
+            children
+        )
+        server.pluginManager.addPermission(parentPermission)
     }
 
     /**

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/ReloadCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/ReloadCommand.kt
@@ -20,7 +20,7 @@ import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.bukkit.annotation.CommandPermission
 
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.reload")
 class ReloadCommand : KoinComponent {
     private val configManager: ConfigManager by inject()
     private val repositoryManager: RepositoryManager by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/AddCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/AddCommand.kt
@@ -28,7 +28,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm add <pluginName> - プラグインを管理対象に追加（依存関係も含む）
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.add")
 class AddCommand : KoinComponent {
     // KoinによるDI
     private val lifecycleService: PluginLifecycleService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/AdoptCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/AdoptCommand.kt
@@ -34,7 +34,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm adopt --soft    - softDependenciesも含める
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.add")
 class AdoptCommand : KoinComponent {
     // KoinによるDI
     private val lifecycleService: PluginLifecycleService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/BackupCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/BackupCommand.kt
@@ -24,7 +24,7 @@ import java.text.DecimalFormat
  * plugins/ディレクトリ全体のバックアップ・リストア機能を提供
  */
 @Command("mpm", "mpm backup")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.backup")
 class BackupCommand : KoinComponent {
     // KoinによるDI
     private val backupManager: ServerBackupManager by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/DependencyCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/DependencyCommand.kt
@@ -26,7 +26,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * プラグインの依存関係を解析・表示する機能を提供
  */
 @Command("mpm", "mpm deps")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.list")
 class DependencyCommand : KoinComponent {
     // KoinによるDI
     private val dependencyAnalyzer: DependencyAnalyzer by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/InitCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/InitCommand.kt
@@ -24,7 +24,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm init - mpm.jsonを生成し、すべてのプラグインをunmanagedとして追加
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.init")
 class InitCommand : KoinComponent {
     // KoinによるDI
     private val projectService: ProjectService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/InstallCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/InstallCommand.kt
@@ -24,7 +24,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm install - mpm.jsonに定義されたプラグインを一括インストール
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.install")
 class InstallCommand : KoinComponent {
     // KoinによるDI
     private val updateService: PluginUpdateService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/ListCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/ListCommand.kt
@@ -24,7 +24,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * プラグインリスト表示コマンドのコントローラー
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.list")
 class ListCommand : KoinComponent {
     // KoinによるDI
     private val infoService: PluginInfoService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/LockCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/LockCommand.kt
@@ -26,7 +26,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm unlock <plugin> - プラグインのロックを解除
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.lock")
 class LockCommand : KoinComponent {
     // Koinによる依存性注入
     private val updateService: PluginUpdateService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/OutdatedCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/OutdatedCommand.kt
@@ -27,7 +27,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm outdatedAll - すべてのプラグインの更新を確認
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.list")
 class OutdatedCommand : KoinComponent {
     // Koinによる依存性注入
     private val infoService: PluginInfoService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/RemoveCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/RemoveCommand.kt
@@ -26,7 +26,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm remove <pluginName> - プラグインを管理対象から除外（ファイルは削除しない）
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.remove")
 class RemoveCommand : KoinComponent {
     // Koinによる依存性注入
     private val lifecycleService: PluginLifecycleService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/UninstallCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/UninstallCommand.kt
@@ -26,7 +26,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm uninstall <pluginName> - プラグインをアンインストール
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.uninstall")
 class UninstallCommand : KoinComponent {
     // KoinによるDI
     private val lifecycleService: PluginLifecycleService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/UpdateCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/UpdateCommand.kt
@@ -26,7 +26,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm update - 新しいバージョンがあるプラグインを更新
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.update")
 class UpdateCommand : KoinComponent {
     // Koinによる依存性注入
     private val updateService: PluginUpdateService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/VersionsCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/VersionsCommand.kt
@@ -26,7 +26,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  * mpm versions <plugin> [--limit <数>] - プラグインの利用可能なバージョン一覧を表示
  */
 @Command("mpm")
-@CommandPermission("mpm.command")
+@CommandPermission("mpm.command.list")
 class VersionsCommand : KoinComponent {
     // Koinによる依存性注入
     private val infoService: PluginInfoService by inject()

--- a/paper/src/main/kotlin/party/morino/mpm/utils/PluginDataUtils.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/utils/PluginDataUtils.kt
@@ -9,7 +9,9 @@
 
 package party.morino.mpm.utils
 
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
 import party.morino.mpm.api.model.plugin.PluginData
 import java.io.File
 import java.util.jar.JarFile
@@ -35,7 +37,7 @@ object PluginDataUtils {
         val paperYml = jarFile.getEntry("paper-plugin.yml")
         val paperYmlStream = jarFile.getInputStream(paperYml)
         val paperYmlReader = paperYmlStream.bufferedReader()
-        val yaml = Yaml()
+        val yaml = Yaml(SafeConstructor(LoaderOptions()))
         val yamlData = yaml.load<Map<String, Any>>(paperYmlReader)
         val name = (yamlData["name"] ?: "").toString()
         val version = (yamlData["version"] ?: "").toString()
@@ -103,7 +105,7 @@ object PluginDataUtils {
         val pluginYml = jarFile.getEntry("plugin.yml")
         val pluginYmlStream = jarFile.getInputStream(pluginYml)
         val pluginYmlReader = pluginYmlStream.bufferedReader()
-        val yaml = Yaml()
+        val yaml = Yaml(SafeConstructor(LoaderOptions()))
         val yamlData = yaml.load<Map<String, Any>>(pluginYmlReader)
         val name = (yamlData["name"] ?: "").toString()
         val version = (yamlData["version"] ?: "").toString()


### PR DESCRIPTION
## Summary
- **YAML safety**: Replace `Yaml()` with `Yaml(SafeConstructor(LoaderOptions()))` in PluginDataUtils to prevent deserialization gadget attacks
- **Permissions**: Add per-command permissions (`mpm.command.add`, `mpm.command.remove`, `mpm.command.install`, `mpm.command.uninstall`, `mpm.command.update`, `mpm.command.list`, `mpm.command.backup`, `mpm.command.lock`, `mpm.command.init`, `mpm.command.reload`)
- **Backward compatibility**: Register `mpm.command` as parent permission containing all children

## Test plan
- [x] `./gradlew check` passes
- [ ] Verify `mpm.command` still grants access to all commands
- [ ] Verify individual permissions work (e.g., `mpm.command.list` without `mpm.command.update`)

Closes #234