### PR TITLE
⚡ Reuse downloader instances, stream downloads, use Dispatchers.IO

### DIFF
--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/AbstractPluginDownloader.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/AbstractPluginDownloader.kt
@@ -10,12 +10,12 @@
 package party.morino.mpm.infrastructure.downloader
 
 import io.ktor.client.*
-import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.get
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -64,8 +64,14 @@ abstract class AbstractPluginDownloader : PluginDownloader {
                     throw Exception("ファイルのダウンロードに失敗しました: ${fileResponse.status}")
                 }
 
+                // ストリーミングでファイルに書き込み（メモリに全体をロードしない）
                 val tempFile = File.createTempFile("plugin-", "-$fileName")
-                tempFile.writeBytes(fileResponse.body())
+                val channel = fileResponse.bodyAsChannel()
+                tempFile.outputStream().use { output ->
+                    channel.toInputStream().use { input ->
+                        input.copyTo(output)
+                    }
+                }
 
                 tempFile
             } catch (e: Exception) {

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/DownloaderRepositoryImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/DownloaderRepositoryImpl.kt
@@ -34,6 +34,11 @@ class DownloaderRepositoryImpl :
     private val plugin: JavaPlugin by inject()
     private val configManager: ConfigManager by inject()
 
+    // ダウンローダーインスタンスを再利用（HttpClientリーク防止）
+    private val spigotDownloader: SpigotDownloader by lazy { SpigotDownloader() }
+    private val modrinthDownloader: ModrinthDownloader by lazy { ModrinthDownloader() }
+    private val githubDownloader: GithubDownloader by lazy { createGithubDownloader() }
+
     /**
      * GitHubダウンローダーを生成する
      * 設定にトークンがある場合は認証付きで生成する
@@ -105,15 +110,15 @@ class DownloaderRepositoryImpl :
     override suspend fun getLatestVersion(urlData: UrlData): VersionData =
         when (urlData) {
             is UrlData.GithubUrlData -> {
-                createGithubDownloader().getLatestVersion(urlData)
+                githubDownloader.getLatestVersion(urlData)
             }
 
             is UrlData.SpigotMcUrlData -> {
-                SpigotDownloader().getLatestVersion(urlData)
+                spigotDownloader.getLatestVersion(urlData)
             }
 
             is UrlData.ModrinthUrlData -> {
-                ModrinthDownloader().getLatestVersion(urlData)
+                modrinthDownloader.getLatestVersion(urlData)
             }
 
             else -> {
@@ -134,15 +139,15 @@ class DownloaderRepositoryImpl :
     ): VersionData =
         when (urlData) {
             is UrlData.GithubUrlData -> {
-                createGithubDownloader().getVersionByName(urlData, versionName)
+                githubDownloader.getVersionByName(urlData, versionName)
             }
 
             is UrlData.SpigotMcUrlData -> {
-                SpigotDownloader().getVersionByName(urlData, versionName)
+                spigotDownloader.getVersionByName(urlData, versionName)
             }
 
             is UrlData.ModrinthUrlData -> {
-                ModrinthDownloader().getVersionByName(urlData, versionName)
+                modrinthDownloader.getVersionByName(urlData, versionName)
             }
 
             else -> {
@@ -159,15 +164,15 @@ class DownloaderRepositoryImpl :
     override suspend fun getAllVersions(urlData: UrlData): List<VersionData> =
         when (urlData) {
             is UrlData.GithubUrlData -> {
-                createGithubDownloader().getAllVersions(urlData)
+                githubDownloader.getAllVersions(urlData)
             }
 
             is UrlData.SpigotMcUrlData -> {
-                SpigotDownloader().getAllVersions(urlData)
+                spigotDownloader.getAllVersions(urlData)
             }
 
             is UrlData.ModrinthUrlData -> {
-                ModrinthDownloader().getAllVersions(urlData)
+                modrinthDownloader.getAllVersions(urlData)
             }
 
             else -> {
@@ -190,15 +195,15 @@ class DownloaderRepositoryImpl :
     ): File? =
         when (urlData) {
             is UrlData.GithubUrlData -> {
-                createGithubDownloader().downloadByVersion(urlData, version, fileNamePattern)
+                githubDownloader.downloadByVersion(urlData, version, fileNamePattern)
             }
 
             is UrlData.SpigotMcUrlData -> {
-                SpigotDownloader().downloadByVersion(urlData, version, fileNamePattern)
+                spigotDownloader.downloadByVersion(urlData, version, fileNamePattern)
             }
 
             is UrlData.ModrinthUrlData -> {
-                ModrinthDownloader().downloadByVersion(urlData, version, fileNamePattern)
+                modrinthDownloader.downloadByVersion(urlData, version, fileNamePattern)
             }
 
             else -> {
@@ -222,16 +227,13 @@ class DownloaderRepositoryImpl :
 
         return when (type) {
             RepositoryType.GITHUB -> {
-                val downloader = createGithubDownloader()
-                val latest = downloader.getLatestVersion(urlData as UrlData.GithubUrlData)
-                downloader.downloadByVersion(urlData, latest, fileNamePattern)
+                val latest = githubDownloader.getLatestVersion(urlData as UrlData.GithubUrlData)
+                githubDownloader.downloadByVersion(urlData, latest, fileNamePattern)
             }
 
             RepositoryType.SPIGOTMC -> {
-                // SpigotMCのダウンロード実装
-                val downloader = SpigotDownloader()
-                val latest = downloader.getLatestVersion(urlData as UrlData.SpigotMcUrlData)
-                downloader.downloadByVersion(urlData, latest, fileNamePattern)
+                val latest = spigotDownloader.getLatestVersion(urlData as UrlData.SpigotMcUrlData)
+                spigotDownloader.downloadByVersion(urlData, latest, fileNamePattern)
             }
 
             RepositoryType.HANGER -> {
@@ -240,10 +242,8 @@ class DownloaderRepositoryImpl :
             }
 
             RepositoryType.MODRINTH -> {
-                // Modrinthのダウンロード実装
-                val downloader = ModrinthDownloader()
-                val latest = downloader.getLatestVersion(urlData as UrlData.ModrinthUrlData)
-                downloader.downloadByVersion(urlData, latest, fileNamePattern)
+                val latest = modrinthDownloader.getLatestVersion(urlData as UrlData.ModrinthUrlData)
+                modrinthDownloader.downloadByVersion(urlData, latest, fileNamePattern)
             }
 
             // UNKNOWNタイプはダウンロードできない

--- a/paper/src/main/kotlin/party/morino/mpm/utils/command/resolver/InstalledPluginParameterType.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/utils/command/resolver/InstalledPluginParameterType.kt
@@ -9,6 +9,7 @@
 
 package party.morino.mpm.utils.command.resolver
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -51,7 +52,7 @@ class InstalledPluginParameterType :
 
         // インストール済み管理対象プラグイン一覧を取得
         val installedPlugins =
-            runBlocking {
+            runBlocking(Dispatchers.IO) {
                 infoService.list(PluginFilter.MANAGED).map { plugin ->
                     plugin.name.value
                 }
@@ -74,7 +75,7 @@ class InstalledPluginParameterType :
     override fun defaultSuggestions(): SuggestionProvider<BukkitCommandActor> {
         // インストール済み管理対象プラグイン一覧を返すサジェストプロバイダー
         return SuggestionProvider { _ ->
-            runBlocking {
+            runBlocking(Dispatchers.IO) {
                 infoService.list(PluginFilter.MANAGED).map { plugin ->
                     plugin.name.value
                 }

--- a/paper/src/main/kotlin/party/morino/mpm/utils/command/resolver/RepositoryPluginParameterType.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/utils/command/resolver/RepositoryPluginParameterType.kt
@@ -48,10 +48,9 @@ class RepositoryPluginParameterType :
         val pluginId = input.readString()
 
         // リポジトリから取得可能なプラグイン一覧を取得
-        // Note: RepositoryManager.getAvailablePlugins()はsuspend関数
-        // ParameterType.parse()はsuspend関数ではないため、runBlockingを使用
+        // ParameterType.parse()はsuspend関数ではないため、Dispatchers.IOで実行
         val availablePlugins =
-            kotlinx.coroutines.runBlocking {
+            kotlinx.coroutines.runBlocking(kotlinx.coroutines.Dispatchers.IO) {
                 repositoryManager.getAvailablePlugins()
             }
 
@@ -73,7 +72,7 @@ class RepositoryPluginParameterType :
         // リポジトリから取得可能なプラグイン一覧を返すサジェストプロバイダー
         return SuggestionProvider { context ->
 
-            kotlinx.coroutines.runBlocking {
+            kotlinx.coroutines.runBlocking(kotlinx.coroutines.Dispatchers.IO) {
                 repositoryManager.getAvailablePlugins().toList()
             }
         }

--- a/paper/src/main/kotlin/party/morino/mpm/utils/command/resolver/VersionSpecifierParameterType.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/utils/command/resolver/VersionSpecifierParameterType.kt
@@ -9,6 +9,7 @@
 
 package party.morino.mpm.utils.command.resolver
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -62,9 +63,9 @@ class VersionSpecifierParameterType :
             val plugin = ctx.getResolvedArgumentOrNull(RepositoryPlugin::class.java)
             return@SuggestionProvider plugin?.let {
                 // プラグインの利用可能なバージョンを取得
-                // Note: getVersions()はsuspend関数のため、runBlockingを使用
+                // getVersions()はsuspend関数のため、Dispatchers.IOで実行
                 val versions =
-                    runBlocking {
+                    runBlocking(Dispatchers.IO) {
                         infoService.getVersions(PluginName(plugin.pluginId)).fold(
                             // エラーの場合は空リストを返す
                             { emptyList() },


### PR DESCRIPTION
## Summary
- **HttpClient reuse**: Cache downloader instances in `DownloaderRepositoryImpl` instead of creating new ones per request, preventing thread/socket leaks
- **Streaming downloads**: Use `bodyAsChannel()` + streaming I/O instead of `body<ByteArray>()` to avoid loading entire JARs into memory
- **Dispatchers.IO**: Use `runBlocking(Dispatchers.IO)` in command resolvers to avoid blocking the main server thread during tab completion

## Test plan
- [ ] Verify plugin downloads still work correctly
- [ ] Verify tab completion doesn't cause server lag
- [ ] Verify no thread/socket leaks over time

Closes #237