### PR TITLE
🧪 Add regression tests for ZIP validation and OutdatedCheckResult

### DIFF
--- a/paper/src/test/kotlin/party/morino/mpm/api/application/model/OutdatedCheckResultTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/api/application/model/OutdatedCheckResultTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related
+ * and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.api.application.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("OutdatedCheckResult tests")
+class OutdatedCheckResultTest {
+    @Test
+    @DisplayName("Contains both outdated plugins and errors")
+    fun testPartialResult() {
+        val outdated = listOf(
+            OutdatedInfo("PluginA", "1.0.0", "2.0.0", true)
+        )
+        val errors = listOf(
+            PluginCheckError("PluginB", "Repository not found")
+        )
+
+        val result = OutdatedCheckResult(outdated, errors)
+
+        assertEquals(1, result.outdatedPlugins.size)
+        assertEquals(1, result.errors.size)
+        assertEquals("PluginA", result.outdatedPlugins[0].pluginName)
+        assertEquals("PluginB", result.errors[0].pluginName)
+    }
+
+    @Test
+    @DisplayName("Empty result when all checks succeed with no updates")
+    fun testEmptyResult() {
+        val result = OutdatedCheckResult(emptyList(), emptyList())
+
+        assertTrue(result.outdatedPlugins.isEmpty())
+        assertTrue(result.errors.isEmpty())
+    }
+
+    @Test
+    @DisplayName("All errors result when no checks succeed")
+    fun testAllErrorsResult() {
+        val errors = listOf(
+            PluginCheckError("PluginA", "Network error"),
+            PluginCheckError("PluginB", "Metadata not found")
+        )
+
+        val result = OutdatedCheckResult(emptyList(), errors)
+
+        assertTrue(result.outdatedPlugins.isEmpty())
+        assertEquals(2, result.errors.size)
+    }
+}

--- a/paper/src/test/kotlin/party/morino/mpm/infrastructure/backup/BackupZipValidationTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/infrastructure/backup/BackupZipValidationTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related
+ * and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.backup
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+@DisplayName("Backup ZIP validation tests")
+class BackupZipValidationTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var pluginsDir: File
+
+    @BeforeEach
+    fun setup() {
+        pluginsDir = File(tempDir, "plugins")
+        pluginsDir.mkdirs()
+    }
+
+    @Test
+    @DisplayName("Rejects ZIP entry with path traversal (Zip Slip)")
+    fun testRejectsZipSlipEntry() {
+        // Zip Slip攻撃を含むZIPファイルを作成
+        val maliciousZip = File(tempDir, "malicious.zip")
+        ZipOutputStream(FileOutputStream(maliciousZip)).use { zos ->
+            // 正常なエントリ
+            zos.putNextEntry(ZipEntry("normal-plugin.jar"))
+            zos.write("normal content".toByteArray())
+            zos.closeEntry()
+
+            // 悪意のあるパストラバーサルエントリ
+            zos.putNextEntry(ZipEntry("../../../etc/malicious.txt"))
+            zos.write("malicious content".toByteArray())
+            zos.closeEntry()
+        }
+
+        // ZIPの全エントリを検証
+        val pluginsDirPrefix = pluginsDir.canonicalPath + File.separator
+        var hasInvalidEntry = false
+
+        ZipInputStream(FileInputStream(maliciousZip)).use { zipIn ->
+            var entry: ZipEntry? = zipIn.nextEntry
+            while (entry != null) {
+                val targetFile = File(pluginsDir, entry.name)
+                if (!targetFile.canonicalPath.startsWith(pluginsDirPrefix) &&
+                    targetFile.canonicalPath != pluginsDir.canonicalPath
+                ) {
+                    hasInvalidEntry = true
+                    break
+                }
+                entry = zipIn.nextEntry
+            }
+        }
+
+        assertTrue(hasInvalidEntry, "Should detect path traversal entry")
+    }
+
+    @Test
+    @DisplayName("Accepts valid ZIP entries within plugins directory")
+    fun testAcceptsValidEntries() {
+        // 正常なZIPファイルを作成
+        val validZip = File(tempDir, "valid.zip")
+        ZipOutputStream(FileOutputStream(validZip)).use { zos ->
+            zos.putNextEntry(ZipEntry("plugin-a.jar"))
+            zos.write("plugin content".toByteArray())
+            zos.closeEntry()
+
+            zos.putNextEntry(ZipEntry("PluginConfig/"))
+            zos.closeEntry()
+
+            zos.putNextEntry(ZipEntry("PluginConfig/config.yml"))
+            zos.write("key: value".toByteArray())
+            zos.closeEntry()
+        }
+
+        // ZIPの全エントリを検証
+        val pluginsDirPrefix = pluginsDir.canonicalPath + File.separator
+        var hasInvalidEntry = false
+
+        ZipInputStream(FileInputStream(validZip)).use { zipIn ->
+            var entry: ZipEntry? = zipIn.nextEntry
+            while (entry != null) {
+                val targetFile = File(pluginsDir, entry.name)
+                if (!targetFile.canonicalPath.startsWith(pluginsDirPrefix) &&
+                    targetFile.canonicalPath != pluginsDir.canonicalPath
+                ) {
+                    hasInvalidEntry = true
+                    break
+                }
+                entry = zipIn.nextEntry
+            }
+        }
+
+        assertFalse(hasInvalidEntry, "Should accept all valid entries")
+    }
+
+    @Test
+    @DisplayName("Rejects sibling directory traversal with File.separator check")
+    fun testRejectsSiblingDirectoryTraversal() {
+        // plugins-malicious のような兄弟ディレクトリへの攻撃
+        // File.separator チェックなしだと "plugins" がプレフィックスとして通ってしまう
+        val siblingDir = File(tempDir, "plugins-malicious")
+        siblingDir.mkdirs()
+
+        val siblingZip = File(tempDir, "sibling.zip")
+        ZipOutputStream(FileOutputStream(siblingZip)).use { zos ->
+            zos.putNextEntry(ZipEntry("../plugins-malicious/evil.jar"))
+            zos.write("evil content".toByteArray())
+            zos.closeEntry()
+        }
+
+        val pluginsDirPrefix = pluginsDir.canonicalPath + File.separator
+        var hasInvalidEntry = false
+
+        ZipInputStream(FileInputStream(siblingZip)).use { zipIn ->
+            var entry: ZipEntry? = zipIn.nextEntry
+            while (entry != null) {
+                val targetFile = File(pluginsDir, entry.name)
+                if (!targetFile.canonicalPath.startsWith(pluginsDirPrefix) &&
+                    targetFile.canonicalPath != pluginsDir.canonicalPath
+                ) {
+                    hasInvalidEntry = true
+                    break
+                }
+                entry = zipIn.nextEntry
+            }
+        }
+
+        assertTrue(hasInvalidEntry, "Should detect sibling directory traversal")
+    }
+}


### PR DESCRIPTION
## Summary
- **BackupZipValidationTest**: Tests Zip Slip attack detection, sibling directory traversal prevention, and valid entry acceptance
- **OutdatedCheckResultTest**: Tests partial results, empty results, and all-errors scenarios for the error aggregation model

## Test plan
- [x] `./gradlew check` passes with all new tests green

Closes #240