### PR TITLE
🐛 Fix repo.json status enum value for docs build

### DIFF
--- a/docs/data/repo.json
+++ b/docs/data/repo.json
@@ -2,7 +2,7 @@
     "commands": [
         {
             "command": "mpm create-repo <pluginName> <url> [fileNameRegex]",
-            "status": "not_implemented",
+            "status": "proposal",
             "category": "repo",
             "description": "URLからリポジトリファイルを自動生成します（GitHub, Modrinth, SpigotMC対応）",
             "arguments": [


### PR DESCRIPTION
Fix deploy docs failure: 'not_implemented' is not a valid enum value. Reverted to 'proposal'.