### PR TITLE
♻️ Consolidate mpm.json persistence through ProjectRepository

### DIFF
--- a/api/src/main/kotlin/party/morino/mpm/api/domain/project/repository/ProjectRepository.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/domain/project/repository/ProjectRepository.kt
@@ -11,7 +11,9 @@
 
 package party.morino.mpm.api.domain.project.repository
 
+import arrow.core.Either
 import party.morino.mpm.api.domain.project.model.MpmProject
+import party.morino.mpm.api.shared.error.MpmError
 
 /**
  * プロジェクトリポジトリのインターフェース
@@ -26,6 +28,15 @@ interface ProjectRepository {
      * @return プロジェクト、存在しない場合はnull
      */
     suspend fun find(): MpmProject?
+
+    /**
+     * プロジェクトを取得（エラー情報付き）
+     *
+     * find()と異なり、ファイル未存在とパースエラーを区別する
+     *
+     * @return Right(project) パース成功時、Left(ConfigNotFound) ファイル未存在時、Left(ConfigParseError) パース失敗時
+     */
+    suspend fun findOrError(): Either<MpmError, MpmProject>
 
     /**
      * プロジェクトを保存

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginInfoServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginInfoServiceImpl.kt
@@ -23,21 +23,19 @@ import party.morino.mpm.api.application.model.OutdatedInfo
 import party.morino.mpm.api.application.model.PluginCheckError
 import party.morino.mpm.api.application.model.PluginFilter
 import party.morino.mpm.api.application.plugin.PluginInfoService
-import party.morino.mpm.api.domain.config.PluginDirectory
 import party.morino.mpm.api.domain.downloader.DownloaderRepository
 import party.morino.mpm.api.domain.downloader.model.UrlData
 import party.morino.mpm.api.domain.plugin.model.ManagedPlugin
 import party.morino.mpm.api.domain.plugin.model.PluginName
+import party.morino.mpm.api.domain.plugin.model.PluginSpec
 import party.morino.mpm.api.domain.plugin.model.VersionDetail
 import party.morino.mpm.api.domain.plugin.service.PluginMetadataManager
-import party.morino.mpm.api.domain.project.dto.MpmConfig
+import party.morino.mpm.api.domain.project.repository.ProjectRepository
 import party.morino.mpm.api.domain.repository.RepositoryManager
 import party.morino.mpm.api.model.plugin.InstalledPlugin
 import party.morino.mpm.api.shared.error.MpmError
 import party.morino.mpm.event.PluginOutdatedEvent
 import party.morino.mpm.utils.BukkitDispatcher
-import party.morino.mpm.utils.Utils
-import java.io.File
 
 /**
  * プラグイン情報の取得を行うApplication Service実装
@@ -48,7 +46,7 @@ class PluginInfoServiceImpl :
     PluginInfoService,
     KoinComponent {
     // Koinによる依存性注入
-    private val pluginDirectory: PluginDirectory by inject()
+    private val projectRepository: ProjectRepository by inject()
     private val repositoryManager: RepositoryManager by inject()
     private val downloaderRepository: DownloaderRepository by inject()
     private val pluginMetadataManager: PluginMetadataManager by inject()
@@ -61,32 +59,14 @@ class PluginInfoServiceImpl :
      * ManagedPluginのリストを返す
      */
     override suspend fun list(filter: PluginFilter): List<ManagedPlugin> {
-        // rootディレクトリとmpm.jsonを取得
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        // mpm.jsonが存在しない場合は空リストを返す
-        if (!configFile.exists()) {
-            return emptyList()
-        }
-
-        // mpm.jsonを読み込む
-        val mpmConfig =
-            try {
-                val jsonString = configFile.readText()
-                Utils.json.decodeFromString<MpmConfig>(jsonString)
-            } catch (e: Exception) {
-                return emptyList()
-            }
-
-        // メタデータディレクトリを取得
-        val metadataDir = pluginDirectory.getMetadataDirectory()
+        // ProjectRepositoryを通じてプロジェクトを取得
+        val project = projectRepository.find() ?: return emptyList()
 
         // 各プラグインのメタデータを読み込んでManagedPluginに変換
         val managedPlugins =
-            mpmConfig.plugins.mapNotNull { (pluginName, versionSpec) ->
+            project.plugins.mapNotNull { (pluginName, spec) ->
                 // unmanagedの場合はスキップ（フィルタ次第で含める）
-                val isUnmanaged = versionSpec == "unmanaged"
+                val isUnmanaged = spec is PluginSpec.Unmanaged
 
                 // フィルタに応じた処理
                 when (filter) {
@@ -94,7 +74,7 @@ class PluginInfoServiceImpl :
                         // unmanagedのみを対象
                         if (!isUnmanaged) return@mapNotNull null
                         // unmanagedプラグインはメタデータがないので、最小限のManagedPluginを作成
-                        return@mapNotNull ManagedPlugin.createUnmanaged(pluginName)
+                        return@mapNotNull ManagedPlugin.createUnmanaged(pluginName.value)
                     }
                     PluginFilter.MANAGED -> {
                         // managedのみを対象
@@ -111,7 +91,7 @@ class PluginInfoServiceImpl :
                 }
 
                 // メタデータを読み込む
-                val metadataResult = pluginMetadataManager.loadMetadata(pluginName)
+                val metadataResult = pluginMetadataManager.loadMetadata(pluginName.value)
                 val dto = metadataResult.getOrElse { return@mapNotNull null }
 
                 // DTOからドメインエンティティに変換
@@ -132,12 +112,8 @@ class PluginInfoServiceImpl :
      * PluginVersionsUseCaseImplから移行したロジック
      */
     override suspend fun getVersions(name: PluginName): Either<MpmError, List<VersionDetail>> {
-        // rootディレクトリを取得
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        // mpm.jsonが存在しない場合はエラー
-        if (!configFile.exists()) {
+        // ProjectRepositoryを通じてプロジェクトの存在を確認
+        if (!projectRepository.exists()) {
             return MpmError.ProjectError.ConfigNotFound.left()
         }
 
@@ -184,26 +160,11 @@ class PluginInfoServiceImpl :
      * CheckOutdatedUseCaseImplから移行したロジック
      */
     override suspend fun checkOutdated(name: PluginName): Either<MpmError, OutdatedInfo?> {
-        // rootディレクトリを取得
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        // mpm.jsonが存在しない場合はエラー
-        if (!configFile.exists()) {
-            return MpmError.ProjectError.ConfigNotFound.left()
-        }
-
-        // mpm.jsonを読み込む
-        val mpmConfig =
-            try {
-                val jsonString = configFile.readText()
-                Utils.json.decodeFromString<MpmConfig>(jsonString)
-            } catch (e: Exception) {
-                return MpmError.ProjectError.ConfigParseError(e.message ?: "不明なエラー").left()
-            }
+        // ProjectRepositoryを通じてプロジェクトを取得（パースエラーも区別する）
+        val project = projectRepository.findOrError().getOrElse { return it.left() }
 
         // プラグインが管理対象に含まれているか確認
-        if (!mpmConfig.plugins.containsKey(name.value)) {
+        if (project.getPluginSpec(name) == null) {
             return MpmError.PluginError.NotManaged(name.value).left()
         }
 
@@ -271,39 +232,24 @@ class PluginInfoServiceImpl :
      * CheckOutdatedUseCaseImplから移行したロジック
      */
     override suspend fun checkAllOutdated(): Either<MpmError, OutdatedCheckResult> {
-        // rootディレクトリを取得
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        // mpm.jsonが存在しない場合はエラー
-        if (!configFile.exists()) {
-            return MpmError.ProjectError.ConfigNotFound.left()
-        }
-
-        // mpm.jsonを読み込む
-        val mpmConfig =
-            try {
-                val jsonString = configFile.readText()
-                Utils.json.decodeFromString<MpmConfig>(jsonString)
-            } catch (e: Exception) {
-                return MpmError.ProjectError.ConfigParseError(e.message ?: "不明なエラー").left()
-            }
+        // ProjectRepositoryを通じてプロジェクトを取得（パースエラーも区別する）
+        val project = projectRepository.findOrError().getOrElse { return it.left() }
 
         // すべての管理対象プラグインの更新情報を収集
         val outdatedInfoList = mutableListOf<OutdatedInfo>()
         // チェックに失敗したプラグインのエラーを収集
         val checkErrors = mutableListOf<PluginCheckError>()
 
-        for (pluginName in mpmConfig.plugins.keys) {
-            // "unmanaged"の場合はスキップ
-            if (mpmConfig.plugins[pluginName] == "unmanaged") {
+        for ((pluginName, spec) in project.plugins) {
+            // unmanagedの場合はスキップ
+            if (spec is PluginSpec.Unmanaged) {
                 continue
             }
 
             // 各プラグインの更新情報を取得し、エラーも記録する
-            checkOutdated(PluginName(pluginName)).fold(
+            checkOutdated(pluginName).fold(
                 { error ->
-                    checkErrors.add(PluginCheckError(pluginName, error.message))
+                    checkErrors.add(PluginCheckError(pluginName.value, error.message))
                 },
                 { outdatedInfo ->
                     if (outdatedInfo != null) {

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginLifecycleServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginLifecycleServiceImpl.kt
@@ -35,12 +35,12 @@ import party.morino.mpm.api.domain.downloader.model.UrlData
 import party.morino.mpm.api.domain.downloader.model.VersionData
 import party.morino.mpm.api.domain.plugin.model.ManagedPlugin
 import party.morino.mpm.api.domain.plugin.model.PluginName
+import party.morino.mpm.api.domain.plugin.model.PluginSpec
 import party.morino.mpm.api.domain.plugin.model.VersionSpecifier
-import party.morino.mpm.api.domain.plugin.model.VersionSpecifierParser
 import party.morino.mpm.api.domain.plugin.service.PluginMetadataManager
-import party.morino.mpm.api.domain.project.dto.MpmConfig
 import party.morino.mpm.api.domain.project.dto.getPluginsSyncingTo
-import party.morino.mpm.api.domain.project.dto.withSortedPlugins
+import party.morino.mpm.api.domain.project.model.MpmProject
+import party.morino.mpm.api.domain.project.repository.ProjectRepository
 import party.morino.mpm.api.domain.repository.RepositoryConfig
 import party.morino.mpm.api.domain.repository.RepositoryManager
 import party.morino.mpm.api.model.plugin.InstalledPlugin
@@ -54,7 +54,6 @@ import party.morino.mpm.event.PluginUninstallEvent
 import party.morino.mpm.utils.BukkitDispatcher
 import party.morino.mpm.utils.DataClassReplacer.replaceTemplate
 import party.morino.mpm.utils.PluginDataUtils
-import party.morino.mpm.utils.Utils
 import java.io.File
 import party.morino.mpm.api.domain.plugin.model.VersionSpecifier as LegacyVersionSpecifier
 
@@ -68,6 +67,7 @@ class PluginLifecycleServiceImpl :
     KoinComponent {
     // 直接依存する infrastructure/domain コンポーネント
     private val pluginDirectory: PluginDirectory by inject()
+    private val projectRepository: ProjectRepository by inject()
     private val repositoryManager: RepositoryManager by inject()
     private val downloaderRepository: DownloaderRepository by inject()
     private val metadataManager: PluginMetadataManager by inject()
@@ -87,13 +87,12 @@ class PluginLifecycleServiceImpl :
         val pluginName = name.value
         val legacyVersion = toLegacyVersionSpecifier(version)
 
-        // rootディレクトリを取得
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        // mpm.jsonが存在しない場合はエラー
-        if (!configFile.exists()) {
-            return MpmError.ProjectError.NotInitialized.left()
+        // ProjectRepositoryを通じてプロジェクトを取得（パースエラーも区別する）
+        val project = projectRepository.findOrError().getOrElse { error ->
+            return when (error) {
+                is MpmError.ProjectError.ConfigNotFound -> MpmError.ProjectError.NotInitialized.left()
+                else -> error.left()
+            }
         }
 
         // リポジトリソースからプラグインが存在するか確認
@@ -111,17 +110,9 @@ class PluginLifecycleServiceImpl :
             createUrlData(firstRepository)
                 ?: return MpmError.DownloadError.RepositoryNotFound(firstRepository.type, pluginName).left()
 
-        // mpm.jsonを読み込む
-        val mpmConfig =
-            try {
-                val jsonString = configFile.readText()
-                Utils.json.decodeFromString<MpmConfig>(jsonString)
-            } catch (e: Exception) {
-                return MpmError.ProjectError.ConfigParseError(e.message ?: "Unknown error").left()
-            }
-
         // 既に追加されているか確認（unmanagedの場合は除外）
-        if (mpmConfig.plugins.containsKey(pluginName) && mpmConfig.plugins[pluginName] != "unmanaged") {
+        val existingSpec = project.getPluginSpec(name)
+        if (existingSpec != null && existingSpec !is PluginSpec.Unmanaged) {
             return MpmError.PluginError.AlreadyExists(pluginName).left()
         }
 
@@ -130,8 +121,7 @@ class PluginLifecycleServiceImpl :
             resolveVersionData(
                 legacyVersion,
                 urlData,
-                firstRepository,
-                mpmConfig,
+                project,
                 pluginName
             ).getOrElse { return it.left() }
 
@@ -159,18 +149,25 @@ class PluginLifecycleServiceImpl :
             return MpmError.PluginError.AddFailed(pluginName, "Cancelled by event").left()
         }
 
-        // pluginsマップに追加
-        val updatedPlugins = mpmConfig.plugins.toMutableMap()
-        val versionToSave =
-            when (legacyVersion) {
-                is LegacyVersionSpecifier.Sync -> VersionSpecifierParser.toVersionString(legacyVersion)
-                is LegacyVersionSpecifier.Latest -> "latest"
-                else -> versionData.version
+        // MpmProjectのプラグインマップを更新
+        // Fixed指定時はリポジトリから解決された正規バージョン名を使用する
+        val resolvedVersionSpec = when (version) {
+            is VersionSpecifier.Fixed -> VersionSpecifier.Fixed(versionData.version)
+            else -> version
+        }
+        val newSpec = PluginSpec.Managed(name, resolvedVersionSpec)
+        val updatedProject = if (existingSpec != null) {
+            // unmanagedからの変換
+            project.updatePlugin(name, newSpec).getOrElse {
+                return MpmError.PluginError.AddFailed(pluginName, it.message).left()
             }
-        updatedPlugins[pluginName] = versionToSave
-
-        // 更新されたMpmConfigを作成し、pluginsをa-Z順にソート
-        val updatedConfig = mpmConfig.copy(plugins = updatedPlugins).withSortedPlugins()
+        } else {
+            // 新規追加
+            project.addPlugin(newSpec).getOrElse {
+                return MpmError.PluginError.AddFailed(pluginName, it.message).left()
+            }
+        }
+        val sortedProject = updatedProject.withSortedPlugins()
 
         // ロールバック用に既存メタデータを退避（unmanagedからの変換時に既存データがある場合）
         val previousMetadata = metadataManager.loadMetadata(pluginName).getOrNull()
@@ -180,12 +177,11 @@ class PluginLifecycleServiceImpl :
             .saveMetadata(pluginName, metadata)
             .getOrElse { return MpmError.PluginError.AddFailed(pluginName, it).left() }
 
-        // メタデータ保存成功後にmpm.jsonを保存
+        // メタデータ保存成功後にProjectRepositoryを通じて保存
         try {
-            val jsonString = Utils.json.encodeToString(updatedConfig)
-            configFile.writeText(jsonString)
+            projectRepository.save(sortedProject)
         } catch (e: Exception) {
-            // mpm.json保存失敗時はメタデータをロールバック（以前の状態に復元）
+            // 保存失敗時はメタデータをロールバック（以前の状態に復元）
             val rollbackError = if (previousMetadata != null) {
                 metadataManager.saveMetadata(pluginName, previousMetadata).fold(
                     { rollbackMsg -> " (rollback also failed: $rollbackMsg)" },
@@ -215,31 +211,21 @@ class PluginLifecycleServiceImpl :
     ): Either<MpmError, Unit> {
         val pluginName = name.value
 
-        // rootディレクトリを取得
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        // mpm.jsonが存在しない場合はエラー
-        if (!configFile.exists()) {
-            return MpmError.ProjectError.NotInitialized.left()
+        // ProjectRepositoryを通じてプロジェクトを取得（パースエラーも区別する）
+        val project = projectRepository.findOrError().getOrElse { error ->
+            return when (error) {
+                is MpmError.ProjectError.ConfigNotFound -> MpmError.ProjectError.NotInitialized.left()
+                else -> error.left()
+            }
         }
 
-        // mpm.jsonを読み込む
-        val mpmConfig =
-            try {
-                val jsonString = configFile.readText()
-                Utils.json.decodeFromString<MpmConfig>(jsonString)
-            } catch (e: Exception) {
-                return MpmError.ProjectError.ConfigParseError(e.message ?: "Unknown error").left()
-            }
-
         // プラグインが管理対象に含まれているか確認
-        if (!mpmConfig.plugins.containsKey(pluginName)) {
+        if (project.getPluginSpec(name) == null) {
             return MpmError.PluginError.NotFound(pluginName).left()
         }
 
         // 逆依存関係チェック（このプラグインにsyncしているプラグインがあるか）
-        val dependents = mpmConfig.getPluginsSyncingTo(pluginName)
+        val dependents = project.toDto().getPluginsSyncingTo(pluginName)
         if (dependents.isNotEmpty()) {
             if (!force) {
                 return MpmError.PluginError.HasDependents(pluginName, dependents).left()
@@ -266,17 +252,15 @@ class PluginLifecycleServiceImpl :
             return MpmError.PluginError.RemoveFailed(pluginName, "Cancelled by event").left()
         }
 
-        // mpm.jsonからプラグインを削除
-        val updatedPlugins = mpmConfig.plugins.toMutableMap()
-        updatedPlugins.remove(pluginName)
+        // MpmProjectからプラグインを削除
+        val updatedProject = project.removePlugin(name).getOrElse {
+            return MpmError.PluginError.RemoveFailed(pluginName, it.message).left()
+        }
+        val sortedProject = updatedProject.withSortedPlugins()
 
-        // 更新されたMpmConfigを作成し、pluginsをa-Z順にソート
-        val updatedConfig = mpmConfig.copy(plugins = updatedPlugins).withSortedPlugins()
-
-        // JSONとして保存
+        // ProjectRepositoryを通じて保存
         return try {
-            val jsonString = Utils.json.encodeToString(updatedConfig)
-            configFile.writeText(jsonString)
+            projectRepository.save(sortedProject)
             Unit.right()
         } catch (e: Exception) {
             MpmError.PluginError.RemoveFailed(pluginName, "Failed to save mpm.json: ${e.message}").left()
@@ -489,26 +473,16 @@ class PluginLifecycleServiceImpl :
     override suspend fun uninstall(name: PluginName): Either<MpmError, Unit> {
         val pluginName = name.value
 
-        // rootディレクトリを取得
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        // mpm.jsonが存在しない場合はエラー
-        if (!configFile.exists()) {
-            return MpmError.ProjectError.NotInitialized.left()
+        // ProjectRepositoryを通じてプロジェクトを取得（パースエラーも区別する）
+        val project = projectRepository.findOrError().getOrElse { error ->
+            return when (error) {
+                is MpmError.ProjectError.ConfigNotFound -> MpmError.ProjectError.NotInitialized.left()
+                else -> error.left()
+            }
         }
 
-        // mpm.jsonを読み込む
-        val mpmConfig =
-            try {
-                val jsonString = configFile.readText()
-                Utils.json.decodeFromString<MpmConfig>(jsonString)
-            } catch (e: Exception) {
-                return MpmError.ProjectError.ConfigParseError(e.message ?: "Unknown error").left()
-            }
-
         // プラグインが管理対象に含まれているか確認
-        if (!mpmConfig.plugins.containsKey(pluginName)) {
+        if (project.getPluginSpec(name) == null) {
             return MpmError.PluginError.NotFound(pluginName).left()
         }
 
@@ -560,17 +534,15 @@ class PluginLifecycleServiceImpl :
         // JARファイルを削除
         targetJarFile?.delete()
 
-        // mpm.jsonからプラグインを削除
-        val updatedPlugins = mpmConfig.plugins.toMutableMap()
-        updatedPlugins.remove(pluginName)
+        // MpmProjectからプラグインを削除
+        val updatedProject = project.removePlugin(name).getOrElse {
+            return MpmError.PluginError.UninstallFailed(pluginName, it.message).left()
+        }
+        val sortedProject = updatedProject.withSortedPlugins()
 
-        // 更新されたMpmConfigを作成し、pluginsをa-Z順にソート
-        val updatedConfig = mpmConfig.copy(plugins = updatedPlugins).withSortedPlugins()
-
-        // JSONとして保存
+        // ProjectRepositoryを通じて保存
         return try {
-            val jsonString = Utils.json.encodeToString(updatedConfig)
-            configFile.writeText(jsonString)
+            projectRepository.save(sortedProject)
             Unit.right()
         } catch (e: Exception) {
             MpmError.PluginError
@@ -588,26 +560,16 @@ class PluginLifecycleServiceImpl :
      * mpm.jsonに含まれていないプラグインのJARファイルを削除する
      */
     override suspend fun removeUnmanaged(): Either<MpmError, Int> {
-        // rootディレクトリを取得
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        // mpm.jsonが存在しない場合はエラー
-        if (!configFile.exists()) {
-            return MpmError.ProjectError.NotInitialized.left()
+        // ProjectRepositoryを通じてプロジェクトを取得（パースエラーも区別する）
+        val project = projectRepository.findOrError().getOrElse { error ->
+            return when (error) {
+                is MpmError.ProjectError.ConfigNotFound -> MpmError.ProjectError.NotInitialized.left()
+                else -> error.left()
+            }
         }
 
-        // mpm.jsonを読み込む
-        val mpmConfig =
-            try {
-                val jsonString = configFile.readText()
-                Utils.json.decodeFromString<MpmConfig>(jsonString)
-            } catch (e: Exception) {
-                return MpmError.ProjectError.ConfigParseError(e.message ?: "Unknown error").left()
-            }
-
         // 管理対象のプラグイン名セット
-        val managedPlugins = mpmConfig.plugins.keys
+        val managedPlugins = project.plugins.keys.map { it.value }.toSet()
 
         // pluginsディレクトリからJARファイルを取得
         val pluginsDir = pluginDirectory.getPluginsDirectory()
@@ -617,6 +579,7 @@ class PluginLifecycleServiceImpl :
             } ?: emptyArray()
 
         // localディレクトリを取得（localディレクトリ内のプラグインは削除対象外）
+        val rootDir = pluginDirectory.getRootDirectory()
         val localDir = File(rootDir, "local")
 
         // 削除されたプラグイン数
@@ -663,8 +626,7 @@ class PluginLifecycleServiceImpl :
     private suspend fun resolveVersionData(
         version: LegacyVersionSpecifier,
         urlData: UrlData,
-        firstRepository: RepositoryConfig,
-        mpmConfig: MpmConfig,
+        project: MpmProject,
         pluginName: String
     ): Either<MpmError, VersionData> =
         when (version) {
@@ -690,7 +652,7 @@ class PluginLifecycleServiceImpl :
                 MpmError.PluginError.VersionResolutionFailed(pluginName, "pattern: specifier is not yet implemented. Use 'latest' or a specific version instead.").left()
             }
             is LegacyVersionSpecifier.Sync -> {
-                resolveSyncVersion(version, urlData, mpmConfig, pluginName)
+                resolveSyncVersion(version, urlData, project, pluginName)
             }
         }
 
@@ -700,12 +662,12 @@ class PluginLifecycleServiceImpl :
     private suspend fun resolveSyncVersion(
         version: LegacyVersionSpecifier.Sync,
         urlData: UrlData,
-        mpmConfig: MpmConfig,
+        project: MpmProject,
         pluginName: String
     ): Either<MpmError, VersionData> {
-        // ターゲットプラグインがmpm.jsonに存在するか確認
-        val targetVersion =
-            mpmConfig.plugins[version.targetPlugin]
+        // ターゲットプラグインがプロジェクトに存在するか確認
+        val targetSpec =
+            project.getPluginSpec(PluginName(version.targetPlugin))
                 ?: return MpmError.PluginError
                     .VersionResolutionFailed(
                         pluginName,
@@ -713,7 +675,7 @@ class PluginLifecycleServiceImpl :
                     ).left()
 
         // ターゲットがunmanagedの場合はエラー
-        if (targetVersion == "unmanaged") {
+        if (targetSpec is PluginSpec.Unmanaged) {
             return MpmError.PluginError
                 .VersionResolutionFailed(
                     pluginName,
@@ -721,8 +683,11 @@ class PluginLifecycleServiceImpl :
                 ).left()
         }
 
+        // ターゲットのバージョン指定を取得
+        val targetManaged = targetSpec as PluginSpec.Managed
+
         // ターゲットもSync指定の場合はエラー
-        if (VersionSpecifierParser.isSyncFormat(targetVersion)) {
+        if (targetManaged.versionRequirement is VersionSpecifier.Sync) {
             return MpmError.PluginError
                 .VersionResolutionFailed(
                     pluginName,
@@ -732,7 +697,7 @@ class PluginLifecycleServiceImpl :
 
         // ターゲットのバージョンを解決
         val resolvedVersion =
-            if (targetVersion == "latest") {
+            if (targetManaged.versionRequirement is VersionSpecifier.Latest) {
                 metadataManager.loadMetadata(version.targetPlugin).fold(
                     {
                         // メタデータがない場合はターゲットのリポジトリから最新バージョンを取得
@@ -766,7 +731,10 @@ class PluginLifecycleServiceImpl :
                     { it.mpmInfo.version.current.raw }
                 )
             } else {
-                targetVersion
+                // Fixed, Tag, Patternの場合はバージョン文字列をDTO経由で取得
+                val dto = project.toDto()
+                dto.plugins[version.targetPlugin] ?: return MpmError.PluginError
+                    .VersionResolutionFailed(pluginName, "Target version not found").left()
             }
 
         // アドオン側で解決されたバージョンに対応するダウンロード情報を取得
@@ -948,19 +916,14 @@ class PluginLifecycleServiceImpl :
             )
         }
 
-        // mpm.jsonを確認して、既に追加済みかどうかチェック
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-        if (configFile.exists()) {
-            try {
-                val mpmConfig = Utils.json.decodeFromString<MpmConfig>(configFile.readText())
-                // 既に追加済み（unmanagedでない）の場合はスキップ
-                if (mpmConfig.plugins.containsKey(pluginName) && mpmConfig.plugins[pluginName] != "unmanaged") {
-                    skippedPlugins.add(pluginName)
-                    return
-                }
-            } catch (e: Exception) {
-                // 読み込みエラーの場合は続行
+        // ProjectRepositoryを通じて、既に追加済みかどうかチェック
+        val currentProject = projectRepository.find()
+        if (currentProject != null) {
+            val existingSpec = currentProject.getPluginSpec(PluginName(pluginName))
+            // 既に追加済み（unmanagedでない）の場合はスキップ
+            if (existingSpec != null && existingSpec !is PluginSpec.Unmanaged) {
+                skippedPlugins.add(pluginName)
+                return
             }
         }
 

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
@@ -43,6 +43,7 @@ import party.morino.mpm.api.domain.project.dto.MpmConfig
 import party.morino.mpm.api.domain.project.dto.getPluginsSyncingTo
 import party.morino.mpm.api.domain.project.dto.topologicalSortPlugins
 import party.morino.mpm.api.domain.project.dto.validateSyncDependencies
+import party.morino.mpm.api.domain.project.repository.ProjectRepository
 import party.morino.mpm.api.domain.repository.RepositoryManager
 import party.morino.mpm.api.model.backup.BackupReason
 import party.morino.mpm.api.model.plugin.InstalledPlugin
@@ -54,7 +55,6 @@ import party.morino.mpm.event.PluginUnlockEvent
 import party.morino.mpm.event.PluginUpdateEvent
 import party.morino.mpm.utils.BukkitDispatcher
 import party.morino.mpm.utils.DataClassReplacer.replaceTemplate
-import party.morino.mpm.utils.Utils
 import java.io.File
 
 /**
@@ -67,6 +67,7 @@ class PluginUpdateServiceImpl :
     KoinComponent {
     // Koinによる依存性注入
     private val pluginDirectory: PluginDirectory by inject()
+    private val projectRepository: ProjectRepository by inject()
     private val pluginMetadataManager: PluginMetadataManager by inject()
     private val repositoryManager: RepositoryManager by inject()
     private val downloaderRepository: DownloaderRepository by inject()
@@ -330,21 +331,10 @@ class PluginUpdateServiceImpl :
      * 一括インストール処理の本体（Mutex保護下で呼び出される）
      */
     private suspend fun executeInstallAll(force: Boolean): Either<MpmError, BulkInstallResult> {
-        // mpm.jsonを読み込む
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        if (!configFile.exists()) {
-            return MpmError.ProjectError.ConfigNotFound.left()
-        }
-
-        val mpmConfig =
-            try {
-                val jsonString = configFile.readText()
-                Utils.json.decodeFromString<MpmConfig>(jsonString)
-            } catch (e: Exception) {
-                return MpmError.ProjectError.ConfigParseError(e.message ?: "不明なエラー").left()
-            }
+        // ProjectRepositoryを通じてプロジェクトを取得（パースエラーも区別する）
+        val mpmConfig = projectRepository.findOrError()
+            .map { it.toDto() }
+            .getOrElse { return it.left() }
 
         // Sync依存関係のバリデーション
         mpmConfig.validateSyncDependencies().onLeft { error ->
@@ -955,22 +945,10 @@ class PluginUpdateServiceImpl :
     }
 
     /**
-     * mpm.jsonを読み込む
+     * mpm.jsonを読み込む（ProjectRepository経由）
      */
-    private fun loadMpmConfig(): MpmConfig? {
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        if (!configFile.exists()) {
-            return null
-        }
-
-        return try {
-            val jsonString = configFile.readText()
-            Utils.json.decodeFromString<MpmConfig>(jsonString)
-        } catch (e: Exception) {
-            null
-        }
+    private suspend fun loadMpmConfig(): MpmConfig? {
+        return projectRepository.find()?.toDto()
     }
 
     /**

--- a/paper/src/main/kotlin/party/morino/mpm/application/project/ProjectServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/project/ProjectServiceImpl.kt
@@ -19,15 +19,13 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import party.morino.mpm.api.application.project.ProjectService
 import party.morino.mpm.api.domain.config.PluginDirectory
-import party.morino.mpm.api.domain.project.dto.MpmConfig
-import party.morino.mpm.api.domain.project.dto.withSortedPlugins
+import party.morino.mpm.api.domain.plugin.model.PluginName
+import party.morino.mpm.api.domain.plugin.model.PluginSpec
 import party.morino.mpm.api.domain.project.model.MpmProject
 import party.morino.mpm.api.domain.project.repository.ProjectRepository
 import party.morino.mpm.api.model.plugin.PluginData
 import party.morino.mpm.api.shared.error.MpmError
 import party.morino.mpm.utils.PluginDataUtils
-import party.morino.mpm.utils.Utils
-import java.io.File
 
 /**
  * プロジェクト管理を行うApplication Service実装
@@ -67,12 +65,8 @@ class ProjectServiceImpl :
         projectName: String,
         overwrite: Boolean
     ): Either<String, Unit> {
-        // rootディレクトリを取得
-        val rootDir = pluginDirectory.getRootDirectory()
-        val configFile = File(rootDir, "mpm.json")
-
-        // 既存のmpm.jsonが存在する場合のチェック
-        if (configFile.exists() && !overwrite) {
+        // ProjectRepositoryを通じて既存プロジェクトの存在を確認
+        if (projectRepository.exists() && !overwrite) {
             return "既にmpm.jsonが存在します。上書きする場合は --overwrite フラグを使用してください。".left()
         }
 
@@ -84,8 +78,8 @@ class ProjectServiceImpl :
                 file.isFile && file.extension == "jar"
             } ?: emptyArray()
 
-        // 各JARファイルからプラグイン名を取得してunmanagedマップを作成
-        val unmanagedPlugins = mutableMapOf<String, String>()
+        // MpmProjectを作成し、各JARファイルのプラグインをunmanagedとして追加
+        var project = MpmProject.create(projectName)
         pluginFiles.forEach { jarFile ->
             try {
                 // JARファイルからプラグイン情報を取得
@@ -98,7 +92,8 @@ class ProjectServiceImpl :
                         }
                     // 自分自身（mpm）は除外し、プラグイン名が空でない場合のみ追加
                     if (pluginName.isNotEmpty() && pluginName != plugin.name) {
-                        unmanagedPlugins[pluginName] = "unmanaged"
+                        project.addPlugin(PluginSpec.Unmanaged(PluginName(pluginName)))
+                            .onRight { project = it }
                     }
                 }
             } catch (e: Exception) {
@@ -106,18 +101,12 @@ class ProjectServiceImpl :
             }
         }
 
-        // MpmConfigを作成し、pluginsをa-Z順にソート
-        val mpmConfig =
-            MpmConfig(
-                name = projectName,
-                version = "1.0.0",
-                plugins = unmanagedPlugins
-            ).withSortedPlugins()
+        // pluginsをa-Z順にソートして保存
+        val sortedProject = project.withSortedPlugins()
 
-        // JSONとして保存
+        // ProjectRepositoryを通じて保存
         return try {
-            val jsonString = Utils.json.encodeToString(mpmConfig)
-            configFile.writeText(jsonString)
+            projectRepository.save(sortedProject)
             Unit.right()
         } catch (e: Exception) {
             "mpm.jsonの作成に失敗しました: ${e.message}".left()

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/persistence/ProjectRepositoryImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/persistence/ProjectRepositoryImpl.kt
@@ -11,6 +11,9 @@
 
 package party.morino.mpm.infrastructure.persistence
 
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import party.morino.mpm.api.domain.config.PluginDirectory
@@ -18,6 +21,7 @@ import party.morino.mpm.api.domain.plugin.model.VersionSpecifierParser
 import party.morino.mpm.api.domain.project.dto.MpmConfig
 import party.morino.mpm.api.domain.project.model.MpmProject
 import party.morino.mpm.api.domain.project.repository.ProjectRepository
+import party.morino.mpm.api.shared.error.MpmError
 import party.morino.mpm.utils.Utils
 import java.io.File
 
@@ -52,6 +56,28 @@ class ProjectRepositoryImpl :
             }
         } catch (e: Exception) {
             null
+        }
+    }
+
+    /**
+     * プロジェクトを取得（エラー情報付き）
+     *
+     * ファイル未存在とパースエラーを区別して返す
+     */
+    override suspend fun findOrError(): Either<MpmError, MpmProject> {
+        val configFile = getConfigFile()
+        if (!configFile.exists()) {
+            return MpmError.ProjectError.ConfigNotFound.left()
+        }
+
+        return try {
+            val jsonString = configFile.readText()
+            val config = Utils.json.decodeFromString<MpmConfig>(jsonString)
+            MpmProject.fromDto(config) { versionString ->
+                VersionSpecifierParser.parse(versionString)
+            }.right()
+        } catch (e: Exception) {
+            MpmError.ProjectError.ConfigParseError(e.message ?: "Unknown error").left()
         }
     }
 


### PR DESCRIPTION
## Summary
- Route all `mpm.json` reads/writes exclusively through `ProjectRepository` instead of direct file I/O scattered across `PluginInfoServiceImpl`, `PluginLifecycleServiceImpl`, `PluginUpdateServiceImpl`, and `ProjectServiceImpl`
- Add `findOrError()` method to `ProjectRepository` interface to distinguish between "file not found" and "parse error" (prevents behavioral regression where corrupt `mpm.json` would appear as "not initialized")
- Use `MpmProject` domain model methods (`addPlugin`, `removePlugin`, `getPluginSpec`, `toDto`) instead of raw `MpmConfig` DTO manipulation in services

## Test plan
- [x] `./gradlew check` passes (all existing tests pass)
- [ ] Manual test: `mpm init` creates `mpm.json` correctly
- [ ] Manual test: `mpm add <plugin>` works with latest/fixed/sync version specifiers
- [ ] Manual test: `mpm remove <plugin>` correctly updates `mpm.json`
- [ ] Manual test: Corrupt `mpm.json` returns parse error (not "not initialized")

Closes #236