### PR TITLE
🐛 Add missing dependencies to MineAuth addon repo files

### DIFF
--- a/repo/public/paper/plugins/MineAuth-addon-betonquest.json
+++ b/repo/public/paper/plugins/MineAuth-addon-betonquest.json
@@ -10,5 +10,9 @@
   ],
   "dependencies": [
     "MineAuth"
-  ]
+  ],
+  "softDependencies": [
+    "BetonQuest"
+  ],
+  "defaultVersion": "sync:MineAuth"
 }

--- a/repo/public/paper/plugins/MineAuth-addon-griefprevention.json
+++ b/repo/public/paper/plugins/MineAuth-addon-griefprevention.json
@@ -10,5 +10,9 @@
   ],
   "dependencies": [
     "MineAuth"
-  ]
+  ],
+  "softDependencies": [
+    "GriefPrevention"
+  ],
+  "defaultVersion": "sync:MineAuth"
 }

--- a/repo/public/paper/plugins/MineAuth-addon-quickshop-hikari.json
+++ b/repo/public/paper/plugins/MineAuth-addon-quickshop-hikari.json
@@ -10,5 +10,9 @@
   ],
   "dependencies": [
     "MineAuth"
-  ]
+  ],
+  "softDependencies": [
+    "QuickShop-Hikari"
+  ],
+  "defaultVersion": "sync:MineAuth"
 }

--- a/repo/public/paper/plugins/MineAuth-addon-voting-plugin.json
+++ b/repo/public/paper/plugins/MineAuth-addon-voting-plugin.json
@@ -10,5 +10,9 @@
   ],
   "dependencies": [
     "MineAuth"
-  ]
+  ],
+  "softDependencies": [
+    "VotingPlugin"
+  ],
+  "defaultVersion": "sync:MineAuth"
 }


### PR DESCRIPTION
## Summary
全4つのMineAuth addonリポファイルに不足情報を追加：
- `softDependencies` — 各addonの連携先プラグイン
- `defaultVersion: "sync:MineAuth"` — 親プラグインとのバージョン同期

| Addon | 追加された softDependency |
|-------|--------------------------|
| MineAuth-addon-griefprevention | GriefPrevention |
| MineAuth-addon-quickshop-hikari | QuickShop-Hikari |
| MineAuth-addon-betonquest | BetonQuest |
| MineAuth-addon-voting-plugin | VotingPlugin |

Closes #266

## Test plan
- [x] JSON syntax valid
- [ ] `mpm add MineAuth-addon-griefprevention --soft` で GriefPrevention も追加されること