### PR TITLE
✨ Add progress reporting to mpm update command

### DIFF
--- a/api/src/main/kotlin/party/morino/mpm/api/application/plugin/PluginUpdateService.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/application/plugin/PluginUpdateService.kt
@@ -30,9 +30,13 @@ interface PluginUpdateService {
      * ロックされていないプラグインを最新バージョンに更新する
      *
      * @param force trueの場合、api-version非互換でも強制更新する
+     * @param progressCallback 進捗メッセージを受け取るコールバック（MiniMessage形式）
      * @return 更新結果一覧
      */
-    suspend fun update(force: Boolean = false): Either<MpmError, List<UpdateResult>>
+    suspend fun update(
+        force: Boolean = false,
+        progressCallback: ((String) -> Unit)? = null
+    ): Either<MpmError, List<UpdateResult>>
 
     /**
      * 指定プラグインを更新する

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
@@ -84,13 +84,16 @@ class PluginUpdateServiceImpl :
      *
      * UpdatePluginUseCaseImplから移行したロジック
      */
-    override suspend fun update(force: Boolean): Either<MpmError, List<UpdateResult>> {
+    override suspend fun update(
+        force: Boolean,
+        progressCallback: ((String) -> Unit)?
+    ): Either<MpmError, List<UpdateResult>> {
         // 既に更新処理が実行中の場合はエラーを返す
         if (!updateMutex.tryLock()) {
             return MpmError.PluginError.UpdateInProgress.left()
         }
         try {
-            return executeUpdate(force)
+            return executeUpdate(force, progressCallback)
         } finally {
             updateMutex.unlock()
         }
@@ -99,8 +102,12 @@ class PluginUpdateServiceImpl :
     /**
      * 更新処理の本体（Mutex保護下で呼び出される）
      */
-    private suspend fun executeUpdate(force: Boolean): Either<MpmError, List<UpdateResult>> {
+    private suspend fun executeUpdate(
+        force: Boolean,
+        progressCallback: ((String) -> Unit)? = null
+    ): Either<MpmError, List<UpdateResult>> {
         // すべてのプラグインの更新情報を取得
+        progressCallback?.invoke("<gray>更新可能なプラグインを確認しています...")
         val checkResult =
             infoService.checkAllOutdated().getOrElse {
                 return it.left()
@@ -111,6 +118,9 @@ class PluginUpdateServiceImpl :
         // チェックに失敗したプラグインを警告表示し、UpdateResultとしても記録
         val checkFailResults = checkResult.errors.map { checkError ->
             plugin.logger.warning("Failed to check update for ${checkError.pluginName}: ${checkError.errorMessage}")
+            progressCallback?.invoke(
+                "<gray>[${checkError.pluginName}] <red>チェック失敗: ${checkError.errorMessage}"
+            )
             UpdateResult(
                 pluginName = checkError.pluginName,
                 oldVersion = "unknown",
@@ -122,10 +132,20 @@ class PluginUpdateServiceImpl :
 
         // 更新が必要なプラグインがある場合、バックアップを作成
         val hasUpdates = outdatedInfoList.any { it.needsUpdate }
+        if (!hasUpdates && checkFailResults.isEmpty()) {
+            progressCallback?.invoke("<green>すべてのプラグインは最新です。")
+        }
         if (hasUpdates) {
+            progressCallback?.invoke("<gray>バックアップを作成しています...")
             backupManager.createBackup(BackupReason.UPDATE).fold(
-                { plugin.logger.warning("バックアップの作成に失敗しました: $it") },
-                { plugin.logger.info("バックアップを作成しました: ${it.fileName}") }
+                {
+                    plugin.logger.warning("バックアップの作成に失敗しました: $it")
+                    progressCallback?.invoke("<yellow>バックアップの作成に失敗しましたが、更新を続行します")
+                },
+                {
+                    plugin.logger.info("バックアップを作成しました: ${it.fileName}")
+                    progressCallback?.invoke("<green>バックアップ完了: ${it.fileName}")
+                }
             )
         }
 
@@ -148,6 +168,9 @@ class PluginUpdateServiceImpl :
             // メタデータを読み込んでロック状態を確認
             val metadata = pluginMetadataManager.loadMetadata(outdatedInfo.pluginName).getOrNull()
             if (metadata == null) {
+                progressCallback?.invoke(
+                    "<gray>[${outdatedInfo.pluginName}] <red>メタデータの読み込みに失敗しました"
+                )
                 updateResults.add(
                     UpdateResult(
                         pluginName = outdatedInfo.pluginName,
@@ -162,6 +185,7 @@ class PluginUpdateServiceImpl :
 
             // ロックされている場合はスキップ
             if (metadata.mpmInfo.settings.lock == true) {
+                progressCallback?.invoke("<gray>[${outdatedInfo.pluginName}] <yellow>ロック中のためスキップ")
                 updateResults.add(
                     UpdateResult(
                         pluginName = outdatedInfo.pluginName,
@@ -188,6 +212,9 @@ class PluginUpdateServiceImpl :
 
             // イベントがキャンセルされた場合はスキップ
             if (updateEvent.isCancelled) {
+                progressCallback?.invoke(
+                    "<gray>[${outdatedInfo.pluginName}] <yellow>更新がキャンセルされました"
+                )
                 updateResults.add(
                     UpdateResult(
                         pluginName = outdatedInfo.pluginName,
@@ -200,12 +227,20 @@ class PluginUpdateServiceImpl :
                 continue
             }
 
+            // イベント通過後にダウンロード開始を通知
+            progressCallback?.invoke(
+                "<gray>[${outdatedInfo.pluginName}] ${outdatedInfo.currentVersion} → ${outdatedInfo.latestVersion} ダウンロード中..."
+            )
+
             // 最新バージョンでインストール（既存のファイルは上書きされる、forceフラグを伝播）
             val installResult = installSinglePlugin(outdatedInfo.pluginName, force, useLatest = true)
 
             installResult.fold(
                 // インストール失敗時
                 { errorMessage ->
+                    progressCallback?.invoke(
+                        "<gray>[${outdatedInfo.pluginName}] <red>更新失敗: $errorMessage"
+                    )
                     updateResults.add(
                         UpdateResult(
                             pluginName = outdatedInfo.pluginName,
@@ -218,6 +253,9 @@ class PluginUpdateServiceImpl :
                 },
                 // インストール成功時
                 {
+                    progressCallback?.invoke(
+                        "<gray>[${outdatedInfo.pluginName}] <green>更新完了 ✓"
+                    )
                     updateResults.add(
                         UpdateResult(
                             pluginName = outdatedInfo.pluginName,
@@ -234,7 +272,7 @@ class PluginUpdateServiceImpl :
 
         // Syncプラグインの連動更新（forceフラグを伝播）
         mpmConfig?.let { config ->
-            updateSyncPlugins(config, updatedPlugins, updateResults, force)
+            updateSyncPlugins(config, updatedPlugins, updateResults, force, progressCallback)
         }
 
         return (checkFailResults + updateResults).right()
@@ -532,7 +570,8 @@ class PluginUpdateServiceImpl :
         mpmConfig: MpmConfig,
         updatedPlugins: Set<String>,
         updateResults: MutableList<UpdateResult>,
-        force: Boolean = false
+        force: Boolean = false,
+        progressCallback: ((String) -> Unit)? = null
     ) {
         // 更新されたプラグインに同期しているプラグインを取得
         val syncPluginsToUpdate = mutableSetOf<String>()
@@ -545,12 +584,20 @@ class PluginUpdateServiceImpl :
         syncPluginsToUpdate.removeAll(updatedPlugins)
 
         // Syncプラグインを更新
+        if (syncPluginsToUpdate.isNotEmpty()) {
+            progressCallback?.invoke("<gray>連動更新を確認しています...")
+        }
         for (syncPluginName in syncPluginsToUpdate) {
             // メタデータを読み込んで現在のバージョンとロック状態を取得
             val metadataEither = pluginMetadataManager.loadMetadata(syncPluginName)
             val currentVersion =
                 metadataEither.fold(
-                    { "unknown" },
+                    {
+                        progressCallback?.invoke(
+                            "<gray>[${syncPluginName}] <yellow>メタデータの読み込みに失敗しました"
+                        )
+                        "unknown"
+                    },
                     { it.mpmInfo.version.current.raw }
                 )
 
@@ -561,6 +608,7 @@ class PluginUpdateServiceImpl :
                     { it.mpmInfo.settings.lock == true }
                 )
             if (isLocked) {
+                progressCallback?.invoke("<gray>[${syncPluginName}] <yellow>ロック中のためスキップ")
                 updateResults.add(
                     UpdateResult(
                         pluginName = syncPluginName,
@@ -574,11 +622,13 @@ class PluginUpdateServiceImpl :
             }
 
             // プラグインをインストール（forceフラグを伝播）
+            progressCallback?.invoke("<gray>[${syncPluginName}] 連動更新をダウンロード中...")
             val installResult = installSinglePlugin(syncPluginName, force)
 
             installResult.fold(
                 // インストール失敗時
                 { errorMessage ->
+                    progressCallback?.invoke("<gray>[${syncPluginName}] <red>連動更新失敗: $errorMessage")
                     updateResults.add(
                         UpdateResult(
                             pluginName = syncPluginName,
@@ -597,6 +647,7 @@ class PluginUpdateServiceImpl :
                             { "unknown" },
                             { it.mpmInfo.version.current.raw }
                         )
+                    progressCallback?.invoke("<gray>[${syncPluginName}] <green>連動更新完了 ✓")
                     updateResults.add(
                         UpdateResult(
                             pluginName = syncPluginName,

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/UpdateCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/UpdateCommand.kt
@@ -50,10 +50,13 @@ class UpdateCommand : KoinComponent {
             return
         }
 
-        sender.sendRichMessage("<gray>プラグインの更新を確認しています...</gray>")
+        // 進捗メッセージをsenderに転送するコールバック
+        val progressCallback: (String) -> Unit = { message ->
+            sender.sendRichMessage(message)
+        }
 
         // PluginUpdateServiceを実行（forceフラグを伝播）
-        updateService.update(force).fold(
+        updateService.update(force, progressCallback).fold(
             // 失敗時の処理
             { error ->
                 sender.sendRichMessage("<red>${error.message}</red>")


### PR DESCRIPTION
## Summary
- `mpm update` コマンドの実行中に、リアルタイムの進捗メッセージを表示するようにしました
- `mpm adopt` で使われている `progressCallback` パターンと同じ設計を採用
- 更新確認、バックアップ作成、プラグインごとのダウンロード/成功/失敗/スキップ、連動更新の各ステップで進捗を報告

## Changes
- `PluginUpdateService.update()` に `progressCallback` パラメータを追加
- `PluginUpdateServiceImpl.executeUpdate()` の各ステップで進捗コールバックを呼び出し
- `UpdateCommand` でコールバックを作成し、`sender.sendRichMessage` で表示

## Test plan
- [ ] `mpm update` を実行して進捗メッセージが表示されることを確認
- [ ] `mpm update --dry-run` が既存通り動作することを確認
- [ ] ロックされたプラグインがある場合にスキップメッセージが表示されることを確認
- [ ] 更新対象がない場合に「すべてのプラグインは最新です」が表示されることを確認
- [ ] スケジューラーからの自動更新が既存通り動作することを確認（progressCallback=null）