### PR TITLE
Fix safe download flow, apiVersion parsing, and dependency check

### DIFF
--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginLifecycleServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginLifecycleServiceImpl.kt
@@ -423,8 +423,15 @@ class PluginLifecycleServiceImpl :
             }
         }
 
-        // 必須依存関係のチェック
-        val pluginData = PluginDataUtils.getPluginData(downloadedFile)
+        // 必須依存関係のチェック（破損JARでも例外を握りつぶしてスキップする）
+        val pluginData = try {
+            PluginDataUtils.getPluginData(downloadedFile)
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            plugin.logger.warning("Failed to read plugin data from downloaded file ($pluginName): ${e.message}")
+            null
+        }
         if (pluginData != null) {
             val requiredDeps = when (pluginData) {
                 is PluginData.BukkitPluginData -> pluginData.depend
@@ -605,8 +612,8 @@ class PluginLifecycleServiceImpl :
             }
         }
 
-        // 管理対象のプラグイン名セット
-        val managedPlugins = project.plugins.keys.map { it.value }.toSet()
+        // 管理対象のプラグイン名セット（大文字小文字を無視して比較するためlowercaseで保持）
+        val managedPlugins = project.plugins.keys.map { it.value.lowercase() }.toSet()
 
         // pluginsディレクトリからJARファイルを取得
         val pluginsDir = pluginDirectory.getPluginsDirectory()
@@ -639,8 +646,8 @@ class PluginLifecycleServiceImpl :
                             is PluginData.PaperPluginData -> pluginData.name
                         }
 
-                    // 管理対象でない場合は削除
-                    if (!managedPlugins.contains(jarPluginName)) {
+                    // 管理対象でない場合は削除（大文字小文字を無視）
+                    if (!managedPlugins.contains(jarPluginName.lowercase())) {
                         if (jarFile.delete()) {
                             removedCount++
                         }
@@ -1355,16 +1362,23 @@ class PluginLifecycleServiceImpl :
                         pinResult.hashWarning?.let { hashMismatchWarnings[repoName] = it }
                     }
 
-                    // 古いJARファイルを削除（新しいファイルと異なる場合のみ）
+                    // 古いJARファイルを削除（新しいファイルの存在を確認してから）
                     if (oldJarFile != null && oldJarFile.exists() && !result.failedPlugins.containsKey(repoName)) {
                         // メタデータから新しいファイル名を取得して比較
                         val newFileName = metadataManager.loadMetadata(repoName).getOrNull()
                             ?.mpmInfo?.download?.fileName
-                        // 古いファイルと新しいファイルが異なる場合に削除（同名の場合はinstall()で上書き済み）
-                        if (newFileName == null || oldJarFile.name != newFileName) {
+                        // メタデータが読めない場合は安全のため削除しない
+                        if (newFileName != null) {
+                            val newFile = File(pluginDirectory.getPluginsDirectory(), newFileName)
                             try {
-                                oldJarFile.delete()
-                                progressCallback?.invoke("<red>[$repoName] 旧ファイル削除: ${oldJarFile.name}")
+                                // canonicalFileで比較し、同一ファイルでないことを確認してから削除する
+                                if (newFile.exists() && oldJarFile.canonicalFile != newFile.canonicalFile) {
+                                    if (oldJarFile.delete()) {
+                                        progressCallback?.invoke("<red>[$repoName] 旧ファイル削除: ${oldJarFile.name}")
+                                    } else {
+                                        plugin.logger.warning("[$repoName] 旧ファイル削除に失敗: ${oldJarFile.name}")
+                                    }
+                                }
                             } catch (e: Exception) {
                                 plugin.logger.warning("[$repoName] 旧ファイル削除に失敗: ${oldJarFile.name} (${e.message})")
                             }

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginLifecycleServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginLifecycleServiceImpl.kt
@@ -395,12 +395,11 @@ class PluginLifecycleServiceImpl :
                 ).left()
         }
 
-        // APIバージョンの互換性チェック
+        // tempファイルに対してAPIバージョンと依存関係の事前チェックを行う
         val compatibilityResult = apiVersionChecker.checkCompatibility(downloadedFile)
         when (compatibilityResult) {
             is CompatibilityResult.Incompatible -> {
                 if (!force) {
-                    // 非互換かつforceでない場合、一時ファイルを削除してエラーを返す
                     downloadedFile.delete()
                     return MpmError.PluginError.ApiVersionIncompatible(
                         pluginName,
@@ -408,7 +407,6 @@ class PluginLifecycleServiceImpl :
                         compatibilityResult.serverApiVersion
                     ).left()
                 }
-                // forceの場合は警告ログを出して続行
                 plugin.logger.warning(
                     "api-version incompatible ($pluginName): " +
                         "plugin=${compatibilityResult.pluginApiVersion}, " +
@@ -416,13 +414,50 @@ class PluginLifecycleServiceImpl :
                 )
             }
             is CompatibilityResult.Unknown -> {
-                // 判定不能の場合はログに警告を出して続行
                 plugin.logger.warning(
                     "Cannot verify api-version compatibility ($pluginName): ${compatibilityResult.reason}"
                 )
             }
             is CompatibilityResult.Compatible -> {
-                // 互換性あり、続行
+                // 互換性あり
+            }
+        }
+
+        // 必須依存関係のチェック
+        val pluginData = PluginDataUtils.getPluginData(downloadedFile)
+        if (pluginData != null) {
+            val requiredDeps = when (pluginData) {
+                is PluginData.BukkitPluginData -> pluginData.depend
+                is PluginData.PaperPluginData -> pluginData.depend
+            }
+            if (requiredDeps.isNotEmpty()) {
+                val project = projectRepository.find()
+                val managedPlugins = project?.plugins?.keys?.map { it.value }?.toSet().orEmpty()
+                val pluginsDir = pluginDirectory.getPluginsDirectory()
+                val installedPluginNames = pluginsDir.listFiles { f ->
+                    f.isFile && f.extension == "jar"
+                }?.mapNotNull { jar ->
+                    try {
+                        val data = PluginDataUtils.getPluginData(jar)
+                        when (data) {
+                            is PluginData.BukkitPluginData -> data.name
+                            is PluginData.PaperPluginData -> data.name
+                            null -> null
+                        }
+                    } catch (_: Exception) { null }
+                }?.toSet().orEmpty()
+
+                val missingDeps = requiredDeps.filter { dep ->
+                    !managedPlugins.contains(dep) && !installedPluginNames.contains(dep)
+                }
+                if (missingDeps.isNotEmpty()) {
+                    val message = "必須依存プラグインが不足しています: ${missingDeps.joinToString(", ")}"
+                    if (!force) {
+                        downloadedFile.delete()
+                        return MpmError.PluginError.InstallFailed(pluginName, message).left()
+                    }
+                    plugin.logger.warning("$pluginName: $message (forced install)")
+                }
             }
         }
 
@@ -430,11 +465,30 @@ class PluginLifecycleServiceImpl :
         val template = mpmInfo.fileNameTemplate ?: "<pluginInfo.name>-<mpmInfo.version.current.normalized>.jar"
         val newFileName = generateFileName(template, pluginInfo.name, mpmInfo.version.current.normalized)
 
-        // 古いファイルを削除（存在する場合）
+        // staged copy: 一時ファイル経由で安全にファイルを置換する
+        val pluginsDir = pluginDirectory.getPluginsDirectory()
+        val targetFile = File(pluginsDir, newFileName)
+        val stagedFile = File(pluginsDir, "$newFileName.tmp")
+        try {
+            downloadedFile.copyTo(stagedFile, overwrite = true)
+            downloadedFile.delete()
+            if (!stagedFile.renameTo(targetFile)) {
+                stagedFile.copyTo(targetFile, overwrite = true)
+                stagedFile.delete()
+            }
+        } catch (e: Exception) {
+            stagedFile.delete()
+            return MpmError.PluginError
+                .InstallFailed(
+                    pluginName,
+                    "Failed to move file: ${e.message}"
+                ).left()
+        }
+
+        // 新しいファイルの配置が成功してから古いファイルを削除する
         val oldFileName = mpmInfo.download.fileName
         var removedInfo: PluginRemovalInfo? = null
         if (oldFileName != null && oldFileName != newFileName) {
-            val pluginsDir = pluginDirectory.getPluginsDirectory()
             val oldFile = File(pluginsDir, oldFileName)
             if (oldFile.exists()) {
                 oldFile.delete()
@@ -444,20 +498,6 @@ class PluginLifecycleServiceImpl :
                         version = mpmInfo.version.current.normalized
                     )
             }
-        }
-
-        // ダウンロードしたファイルをpluginsディレクトリに移動
-        val pluginsDir = pluginDirectory.getPluginsDirectory()
-        val targetFile = File(pluginsDir, newFileName)
-        try {
-            downloadedFile.copyTo(targetFile, overwrite = true)
-            downloadedFile.delete()
-        } catch (e: Exception) {
-            return MpmError.PluginError
-                .InstallFailed(
-                    pluginName,
-                    "Failed to move file: ${e.message}"
-                ).left()
         }
 
         // ファイル名をメタデータに記録して保存

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
@@ -47,6 +47,7 @@ import party.morino.mpm.api.domain.project.repository.ProjectRepository
 import party.morino.mpm.api.domain.repository.RepositoryManager
 import party.morino.mpm.api.model.backup.BackupReason
 import party.morino.mpm.api.model.plugin.InstalledPlugin
+import party.morino.mpm.api.model.plugin.PluginData
 import party.morino.mpm.api.model.plugin.RepositoryPlugin
 import party.morino.mpm.api.shared.error.MpmError
 import party.morino.mpm.event.PluginInstallEvent
@@ -55,6 +56,7 @@ import party.morino.mpm.event.PluginUnlockEvent
 import party.morino.mpm.event.PluginUpdateEvent
 import party.morino.mpm.utils.BukkitDispatcher
 import party.morino.mpm.utils.DataClassReplacer.replaceTemplate
+import party.morino.mpm.utils.PluginDataUtils
 import java.io.File
 
 /**
@@ -708,32 +710,11 @@ class PluginUpdateServiceImpl :
             return "プラグインファイルのダウンロードに失敗しました。".left()
         }
 
-        // APIバージョンの互換性チェック
-        val compatibilityResult = apiVersionChecker.checkCompatibility(downloadedFile)
-        when (compatibilityResult) {
-            is CompatibilityResult.Incompatible -> {
-                if (!force) {
-                    // 非互換かつforceでない場合、一時ファイルを削除してエラーを返す
-                    downloadedFile.delete()
-                    return ("[API_VERSION_INCOMPATIBLE] api-version非互換: " +
-                        "プラグインは${compatibilityResult.pluginApiVersion}を要求していますが、" +
-                        "サーバーは${compatibilityResult.serverApiVersion}です").left()
-                }
-                // forceの場合は警告ログを出して続行
-                plugin.logger.warning(
-                    "api-version incompatible ($pluginName): " +
-                        "plugin=${compatibilityResult.pluginApiVersion}, " +
-                        "server=${compatibilityResult.serverApiVersion}. Forced install."
-                )
-            }
-            is CompatibilityResult.Unknown -> {
-                plugin.logger.warning(
-                    "Cannot verify api-version compatibility ($pluginName): ${compatibilityResult.reason}"
-                )
-            }
-            is CompatibilityResult.Compatible -> {
-                // 互換性あり、続行
-            }
+        // tempファイルに対してAPIバージョンと依存関係の事前チェックを行う
+        // チェックに失敗した場合はtempファイルを削除して早期リターン
+        validateDownloadedPlugin(downloadedFile, pluginName, force).onLeft { error ->
+            downloadedFile.delete()
+            return error.left()
         }
 
         // 更新後のメタデータからバージョン情報を取得してファイル名を生成
@@ -741,11 +722,29 @@ class PluginUpdateServiceImpl :
         val updatedVersion = updatedMetadataWithLatest.mpmInfo.version.current.normalized
         val newFileName = generateFileName(template, pluginInfoDto.name, updatedVersion)
 
-        // 古いファイルを削除（存在する場合）
+        // staged copy: 一時ファイル経由で安全にファイルを置換する
+        // 同名ファイルの上書き中にクラッシュしても既存JARが壊れないようにする
+        val pluginsDir = pluginDirectory.getPluginsDirectory()
+        val targetFile = File(pluginsDir, newFileName)
+        val stagedFile = File(pluginsDir, "$newFileName.tmp")
+        try {
+            downloadedFile.copyTo(stagedFile, overwrite = true)
+            downloadedFile.delete()
+            // staged fileを最終位置にリネーム（同一ファイルシステム上ではアトミック）
+            if (!stagedFile.renameTo(targetFile)) {
+                // renameToが失敗した場合はcopy+deleteにフォールバック
+                stagedFile.copyTo(targetFile, overwrite = true)
+                stagedFile.delete()
+            }
+        } catch (e: Exception) {
+            stagedFile.delete()
+            return "プラグインファイルの移動に失敗しました: ${e.message}".left()
+        }
+
+        // 新しいファイルの配置が成功してから古いファイルを削除する
         val oldFileName = mpmInfoDto.download.fileName
         var removedInfo: PluginRemovalInfo? = null
         if (oldFileName != null && oldFileName != newFileName) {
-            val pluginsDir = pluginDirectory.getPluginsDirectory()
             val oldFile = File(pluginsDir, oldFileName)
             if (oldFile.exists()) {
                 oldFile.delete()
@@ -755,15 +754,6 @@ class PluginUpdateServiceImpl :
                         version = mpmInfoDto.version.current.normalized
                     )
             }
-        }
-
-        val pluginsDir = pluginDirectory.getPluginsDirectory()
-        val targetFile = File(pluginsDir, newFileName)
-        try {
-            downloadedFile.copyTo(targetFile, overwrite = true)
-            downloadedFile.delete()
-        } catch (e: Exception) {
-            return "プラグインファイルの移動に失敗しました: ${e.message}".left()
         }
 
         // ファイル名をmetadataに記録して保存
@@ -875,64 +865,46 @@ class PluginUpdateServiceImpl :
             return "プラグインファイルのダウンロードに失敗しました。".left()
         }
 
-        // APIバージョンの互換性チェック
-        val compatibilityResult = apiVersionChecker.checkCompatibility(downloadedFile)
-        when (compatibilityResult) {
-            is CompatibilityResult.Incompatible -> {
-                if (!force) {
-                    // 非互換かつforceでない場合、一時ファイルを削除してエラーを返す
-                    downloadedFile.delete()
-                    return ("[API_VERSION_INCOMPATIBLE] api-version非互換: " +
-                        "プラグインは${compatibilityResult.pluginApiVersion}を要求していますが、" +
-                        "サーバーは${compatibilityResult.serverApiVersion}です").left()
-                }
-                // forceの場合は警告ログを出して続行
-                plugin.logger.warning(
-                    "api-version incompatible ($pluginName): " +
-                        "plugin=${compatibilityResult.pluginApiVersion}, " +
-                        "server=${compatibilityResult.serverApiVersion}. Forced install."
-                )
-            }
-            is CompatibilityResult.Unknown -> {
-                plugin.logger.warning(
-                    "Cannot verify api-version compatibility ($pluginName): ${compatibilityResult.reason}"
-                )
-            }
-            is CompatibilityResult.Compatible -> {
-                // 互換性あり、続行
-            }
+        // tempファイルに対してAPIバージョンと依存関係の事前チェックを行う
+        // チェックに失敗した場合はtempファイルを削除して早期リターン
+        validateDownloadedPlugin(downloadedFile, pluginName, force).onLeft { error ->
+            downloadedFile.delete()
+            return error.left()
         }
 
         // ファイル名を生成
         val template = firstRepository.fileNameTemplate ?: "<pluginInfo.name>-<mpmInfo.version.current.normalized>.jar"
         val newFileName = generateFileName(template, pluginName, metadata.mpmInfo.version.current.normalized)
 
-        // 古いファイルを削除（存在する場合）
+        // staged copy: 一時ファイル経由で安全にファイルを置換する
+        val pluginsDir = pluginDirectory.getPluginsDirectory()
+        val targetFile = File(pluginsDir, newFileName)
+        val stagedFile = File(pluginsDir, "$newFileName.tmp")
+        try {
+            downloadedFile.copyTo(stagedFile, overwrite = true)
+            downloadedFile.delete()
+            if (!stagedFile.renameTo(targetFile)) {
+                stagedFile.copyTo(targetFile, overwrite = true)
+                stagedFile.delete()
+            }
+        } catch (e: Exception) {
+            stagedFile.delete()
+            return "プラグインファイルの移動に失敗しました: ${e.message}".left()
+        }
+
+        // 新しいファイルの配置が成功してから古いファイルを削除する
         val oldFileName = metadata.mpmInfo.download.fileName
         var removedInfo: PluginRemovalInfo? = null
         if (oldFileName != null && oldFileName != newFileName) {
-            val pluginsDir = pluginDirectory.getPluginsDirectory()
             val oldFile = File(pluginsDir, oldFileName)
             if (oldFile.exists()) {
                 oldFile.delete()
-                pluginMetadataManager.loadMetadata(pluginName).onRight { existingMetadata ->
-                    removedInfo =
-                        PluginRemovalInfo(
-                            name = pluginName,
-                            version = existingMetadata.mpmInfo.version.current.normalized
-                        )
-                }
+                removedInfo =
+                    PluginRemovalInfo(
+                        name = pluginName,
+                        version = metadata.mpmInfo.version.current.normalized
+                    )
             }
-        }
-
-        // プラグインディレクトリにコピー
-        val pluginsDir = pluginDirectory.getPluginsDirectory()
-        val targetFile = File(pluginsDir, newFileName)
-        try {
-            downloadedFile.copyTo(targetFile, overwrite = true)
-            downloadedFile.delete()
-        } catch (e: Exception) {
-            return "プラグインファイルの移動に失敗しました: ${e.message}".left()
         }
 
         // ファイル名をmetadataに記録して保存
@@ -991,6 +963,90 @@ class PluginUpdateServiceImpl :
                 )
             else -> expected
         }
+    }
+
+    /**
+     * ダウンロード済みのtempファイルに対してAPIバージョンと依存関係の事前検証を行う
+     *
+     * @param downloadedFile ダウンロード済みのtempファイル
+     * @param pluginName プラグイン名（ログ出力用）
+     * @param force trueの場合、非互換でも警告のみで続行する
+     * @return 検証成功時はUnit、失敗時はエラーメッセージ
+     */
+    private suspend fun validateDownloadedPlugin(
+        downloadedFile: File,
+        pluginName: String,
+        force: Boolean
+    ): Either<String, Unit> {
+        // tempファイルからプラグインデータを抽出
+        val pluginData = PluginDataUtils.getPluginData(downloadedFile)
+
+        // APIバージョンの互換性チェック
+        val compatibilityResult = apiVersionChecker.checkCompatibility(downloadedFile)
+        when (compatibilityResult) {
+            is CompatibilityResult.Incompatible -> {
+                if (!force) {
+                    return ("[API_VERSION_INCOMPATIBLE] api-version非互換: " +
+                        "プラグインは${compatibilityResult.pluginApiVersion}を要求していますが、" +
+                        "サーバーは${compatibilityResult.serverApiVersion}です").left()
+                }
+                plugin.logger.warning(
+                    "api-version incompatible ($pluginName): " +
+                        "plugin=${compatibilityResult.pluginApiVersion}, " +
+                        "server=${compatibilityResult.serverApiVersion}. Forced install."
+                )
+            }
+            is CompatibilityResult.Unknown -> {
+                plugin.logger.warning(
+                    "Cannot verify api-version compatibility ($pluginName): ${compatibilityResult.reason}"
+                )
+            }
+            is CompatibilityResult.Compatible -> {
+                // 互換性あり
+            }
+        }
+
+        // 必須依存関係のチェック
+        if (pluginData != null) {
+            val requiredDeps = when (pluginData) {
+                is PluginData.BukkitPluginData -> pluginData.depend
+                is PluginData.PaperPluginData -> pluginData.depend
+            }
+
+            if (requiredDeps.isNotEmpty()) {
+                // mpm.jsonに登録済みのプラグイン名を取得
+                val managedPlugins = loadMpmConfig()?.plugins?.keys.orEmpty()
+                // pluginsディレクトリに存在するプラグイン名を取得
+                val pluginsDir = pluginDirectory.getPluginsDirectory()
+                val installedPluginNames = pluginsDir.listFiles { f ->
+                    f.isFile && f.extension == "jar"
+                }?.mapNotNull { jar ->
+                    try {
+                        val data = PluginDataUtils.getPluginData(jar)
+                        when (data) {
+                            is PluginData.BukkitPluginData -> data.name
+                            is PluginData.PaperPluginData -> data.name
+                            null -> null
+                        }
+                    } catch (_: Exception) { null }
+                }?.toSet().orEmpty()
+
+                // 管理対象とインストール済みのどちらにもない依存関係を検出
+                val missingDeps = requiredDeps.filter { dep ->
+                    !managedPlugins.contains(dep) && !installedPluginNames.contains(dep)
+                }
+
+                if (missingDeps.isNotEmpty()) {
+                    val message = "必須依存プラグインが不足しています: ${missingDeps.joinToString(", ")}"
+                    if (!force) {
+                        return message.left()
+                    }
+                    plugin.logger.warning("$pluginName: $message (forced install)")
+                }
+            }
+        }
+
+        return Unit.right()
     }
 
     /**

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
@@ -978,8 +978,15 @@ class PluginUpdateServiceImpl :
         pluginName: String,
         force: Boolean
     ): Either<String, Unit> {
-        // tempファイルからプラグインデータを抽出
-        val pluginData = PluginDataUtils.getPluginData(downloadedFile)
+        // tempファイルからプラグインデータを抽出（破損JARでも例外を握りつぶしてスキップする）
+        val pluginData = try {
+            PluginDataUtils.getPluginData(downloadedFile)
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            plugin.logger.warning("Failed to read plugin data from downloaded file ($pluginName): ${e.message}")
+            null
+        }
 
         // APIバージョンの互換性チェック
         val compatibilityResult = apiVersionChecker.checkCompatibility(downloadedFile)

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/backup/ServerBackupManagerImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/backup/ServerBackupManagerImpl.kt
@@ -30,6 +30,7 @@ import java.io.FileOutputStream
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
+import java.util.logging.Logger
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
@@ -52,6 +53,7 @@ class ServerBackupManagerImpl :
     KoinComponent {
     // Koinによる依存性注入
     private val pluginDirectory: PluginDirectory by inject()
+    private val logger: Logger = Logger.getLogger(ServerBackupManagerImpl::class.java.name)
 
     // インデックスファイル名
     private val indexFileName = "index.yaml"
@@ -315,7 +317,7 @@ class ServerBackupManagerImpl :
 
                 for (backup in backupsToDelete) {
                     deleteBackup(backup.id).fold(
-                        { /* エラーの場合はスキップ */ },
+                        { error -> logger.warning("バックアップ ${backup.id} の削除に失敗: $error") },
                         { deletedCount++ }
                     )
                 }
@@ -392,6 +394,8 @@ class ServerBackupManagerImpl :
                 val yamlString = indexFile.readText()
                 Yaml.default.decodeFromString(BackupIndex.serializer(), yamlString)
             } catch (e: Exception) {
+                // インデックスファイルの破損を警告し、空のインデックスで続行する
+                logger.warning("バックアップインデックスの読み込みに失敗しました（${indexFile.absolutePath}）: ${e.message}")
                 BackupIndex()
             }
         } else {

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/repository/LocalRepositorySource.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/repository/LocalRepositorySource.kt
@@ -63,10 +63,17 @@ class LocalRepositorySource(
      */
     override suspend fun getRepositoryFile(pluginName: String): RepositoryFile? =
         withContext(Dispatchers.IO) {
-            val file = File(directory, "$pluginName.json")
+            // 大文字小文字を無視してファイルを検索（Linux環境ではファイル名がcase-sensitive）
+            val candidates = directory.listFiles { f ->
+                f.isFile && f.extension.equals("json", ignoreCase = true) &&
+                    f.nameWithoutExtension.equals(pluginName, ignoreCase = true)
+            } ?: emptyArray()
+            // 完全一致を優先し、なければcase-insensitiveの最初のマッチを使う
+            val file = candidates.firstOrNull { it.nameWithoutExtension == pluginName }
+                ?: candidates.firstOrNull()
 
-            // ファイルが存在しない場合はnullを返す
-            if (!file.exists() || !file.isFile) {
+            // ファイルが見つからない場合はnullを返す
+            if (file == null) {
                 return@withContext null
             }
 

--- a/paper/src/main/kotlin/party/morino/mpm/utils/PluginDataUtils.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/utils/PluginDataUtils.kt
@@ -58,10 +58,11 @@ object PluginDataUtils {
 
     private fun getPaperPluginData(jarFile: JarFile): PluginData.PaperPluginData {
         val paperYml = jarFile.getEntry("paper-plugin.yml")
-        val paperYmlStream = jarFile.getInputStream(paperYml)
-        val paperYmlReader = paperYmlStream.bufferedReader()
-        val yaml = Yaml(SafeConstructor(LoaderOptions()))
-        val yamlData = yaml.load<Map<String, Any>>(paperYmlReader)
+        // InputStream/BufferedReaderをuse{}で確実にクローズする（リソースリーク防止）
+        val yamlData = jarFile.getInputStream(paperYml).bufferedReader().use { reader ->
+            val yaml = Yaml(SafeConstructor(LoaderOptions()))
+            yaml.load<Map<String, Any>>(reader)
+        }
         val name = (yamlData["name"] ?: "").toString()
         val version = (yamlData["version"] ?: "").toString()
         val main = (yamlData["main"] ?: "").toString()
@@ -126,10 +127,11 @@ object PluginDataUtils {
 
     private fun getBukkitPluginData(jarFile: JarFile): PluginData.BukkitPluginData {
         val pluginYml = jarFile.getEntry("plugin.yml")
-        val pluginYmlStream = jarFile.getInputStream(pluginYml)
-        val pluginYmlReader = pluginYmlStream.bufferedReader()
-        val yaml = Yaml(SafeConstructor(LoaderOptions()))
-        val yamlData = yaml.load<Map<String, Any>>(pluginYmlReader)
+        // InputStream/BufferedReaderをuse{}で確実にクローズする（リソースリーク防止）
+        val yamlData = jarFile.getInputStream(pluginYml).bufferedReader().use { reader ->
+            val yaml = Yaml(SafeConstructor(LoaderOptions()))
+            yaml.load<Map<String, Any>>(reader)
+        }
         val name = (yamlData["name"] ?: "").toString()
         val version = (yamlData["version"] ?: "").toString()
         val main = (yamlData["main"] ?: "").toString()

--- a/paper/src/main/kotlin/party/morino/mpm/utils/PluginDataUtils.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/utils/PluginDataUtils.kt
@@ -17,6 +17,29 @@ import java.io.File
 import java.util.jar.JarFile
 
 object PluginDataUtils {
+    /**
+     * YAMLからapi-versionの値を安全に文字列として取得する
+     * SnakeYAMLは "api-version: 1.20" をDouble 1.2としてパースするため、
+     * Number型の場合は元の表現を復元する
+     */
+    internal fun parseApiVersion(raw: Any?): String {
+        if (raw == null) return ""
+        // String型ならそのまま返す（クォートされたYAML値）
+        if (raw is String) return raw
+        // Number型の場合、SnakeYAMLがfloatとしてパースしている
+        // 例: 1.20 → Double(1.2), 1.21 → Double(1.21)
+        if (raw is Number) {
+            val str = raw.toString()
+            // "1.2" のようにマイナーバージョンが1桁の場合、"1.20"に復元する
+            val parts = str.split(".")
+            if (parts.size == 2 && parts[1].length == 1) {
+                return "${parts[0]}.${parts[1]}0"
+            }
+            return str
+        }
+        return raw.toString()
+    }
+
     fun getPluginData(file: File): PluginData? {
         // JarFileをuse{}で確実にクローズする（リソースリーク防止）
         return JarFile(file).use { jarFile ->
@@ -43,7 +66,7 @@ object PluginDataUtils {
         val version = (yamlData["version"] ?: "").toString()
         val main = (yamlData["main"] ?: "").toString()
         val description = (yamlData["description"] ?: "").toString()
-        val apiVersion = (yamlData["api-version"] ?: "").toString()
+        val apiVersion = parseApiVersion(yamlData["api-version"])
         val bootstrapper = (yamlData["bootstrapper"] ?: "").toString()
         val loader = (yamlData["loader"] ?: "").toString()
         val author = (yamlData["author"] ?: "").toString()
@@ -113,7 +136,7 @@ object PluginDataUtils {
         val description = (yamlData["description"] ?: "").toString()
         val author = (yamlData["author"] ?: "").toString()
         val website = (yamlData["website"] ?: "").toString()
-        val apiVersion = (yamlData["api-version"] ?: "").toString()
+        val apiVersion = parseApiVersion(yamlData["api-version"])
 
         // Bukkit形式の依存関係を解析
         val depend = parseStringList(yamlData["depend"])

--- a/paper/src/test/kotlin/party/morino/mpm/utils/PluginDataTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/utils/PluginDataTest.kt
@@ -11,6 +11,7 @@ package party.morino.mpm.utils
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import party.morino.mpm.api.model.plugin.PluginData
 import party.morino.mpm.utils.PluginDataUtils
@@ -30,5 +31,34 @@ class PluginDataTest {
         val paperPluginData = PluginDataUtils.getPluginData(paperPluginFile) as PluginData.PaperPluginData
         println(paperPluginData)
         assertEquals("1.20", paperPluginData.apiVersion)
+    }
+
+    @Test
+    @DisplayName("parseApiVersion preserves trailing zero from SnakeYAML float")
+    fun testParseApiVersionTrailingZero() {
+        // SnakeYAML parses "api-version: 1.20" as Double 1.2
+        assertEquals("1.20", PluginDataUtils.parseApiVersion(1.2))
+    }
+
+    @Test
+    @DisplayName("parseApiVersion keeps normal version string as-is")
+    fun testParseApiVersionString() {
+        assertEquals("1.21", PluginDataUtils.parseApiVersion("1.21"))
+        assertEquals("1.20", PluginDataUtils.parseApiVersion("1.20"))
+    }
+
+    @Test
+    @DisplayName("parseApiVersion handles multi-digit minor version")
+    fun testParseApiVersionMultiDigit() {
+        // SnakeYAML parses "api-version: 1.21" as Double 1.21
+        assertEquals("1.21", PluginDataUtils.parseApiVersion(1.21))
+        assertEquals("1.13", PluginDataUtils.parseApiVersion(1.13))
+    }
+
+    @Test
+    @DisplayName("parseApiVersion handles null and empty")
+    fun testParseApiVersionNullEmpty() {
+        assertEquals("", PluginDataUtils.parseApiVersion(null))
+        assertEquals("", PluginDataUtils.parseApiVersion(""))
     }
 }

--- a/paper/src/test/kotlin/party/morino/mpm/utils/PluginDataTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/utils/PluginDataTest.kt
@@ -10,9 +10,13 @@
 package party.morino.mpm.utils
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
 import party.morino.mpm.api.model.plugin.PluginData
 import party.morino.mpm.utils.PluginDataUtils
 import java.io.File
@@ -60,5 +64,39 @@ class PluginDataTest {
     fun testParseApiVersionNullEmpty() {
         assertEquals("", PluginDataUtils.parseApiVersion(null))
         assertEquals("", PluginDataUtils.parseApiVersion(""))
+    }
+
+    @Test
+    @DisplayName("SnakeYAML cannot distinguish unquoted 1.2 from 1.20")
+    fun testSnakeYamlCannotDistinguish() {
+        val yaml = Yaml(SafeConstructor(LoaderOptions()))
+
+        // SnakeYAML parses both as the same Double
+        val parsed120 = yaml.load<Map<String, Any>>("api-version: 1.20")
+        val parsed12 = yaml.load<Map<String, Any>>("api-version: 1.2")
+        assertEquals(parsed120["api-version"], parsed12["api-version"],
+            "SnakeYAML treats unquoted 1.2 and 1.20 as the same Double")
+
+        // parseApiVersion restores trailing zero for both
+        assertEquals("1.20", PluginDataUtils.parseApiVersion(parsed120["api-version"]))
+        assertEquals("1.20", PluginDataUtils.parseApiVersion(parsed12["api-version"]))
+    }
+
+    @Test
+    @DisplayName("Quoted strings are preserved correctly by SnakeYAML")
+    fun testSnakeYamlQuotedStringsPreserved() {
+        val yaml = Yaml(SafeConstructor(LoaderOptions()))
+
+        // Quoted values are preserved as strings
+        val quoted120 = yaml.load<Map<String, Any>>("api-version: '1.20'")
+        val quoted12 = yaml.load<Map<String, Any>>("api-version: '1.2'")
+
+        assertEquals("1.20", PluginDataUtils.parseApiVersion(quoted120["api-version"]))
+        assertEquals("1.2", PluginDataUtils.parseApiVersion(quoted12["api-version"]))
+        assertNotEquals(
+            PluginDataUtils.parseApiVersion(quoted120["api-version"]),
+            PluginDataUtils.parseApiVersion(quoted12["api-version"]),
+            "Quoted strings should be distinguishable"
+        )
     }
 }


### PR DESCRIPTION
## Summary

- **Fix SnakeYAML api-version float parsing**: `api-version: 1.20` (unquoted in YAML) was parsed as `Double 1.2`, causing incorrect version compatibility checks
- **Implement staged copy for JAR replacement**: Use `.tmp` file + rename instead of direct overwrite to prevent JAR corruption
- **Copy-then-delete ordering**: New JAR file is placed before old JAR is deleted, preventing data loss on failure
- **Add dependency validation**: Downloaded temp files are checked for missing required dependencies before installation
- **Fix #277**: Case-insensitive comparison in `removeUnmanaged` to prevent deleting managed plugins
- **Fix #278**: Close `InputStream`/`BufferedReader` with `.use{}` in `PluginDataUtils` to prevent resource leaks
- **Fix #279**: Log warning on backup index corruption instead of silent failure
- **Fix #280**: Only delete old JAR in `adoptAll` when new file is confirmed to exist (canonicalFile comparison)
- **Fix #281**: Case-insensitive file lookup in `LocalRepositorySource` for Linux compatibility
- **Fix Codex review**: Wrap `getPluginData` in try/catch with `CancellationException` rethrow

## Test plan

- [x] `parseApiVersion` unit tests pass (trailing zero preservation, multi-digit minor, null/empty handling)
- [x] Existing `PaperPluginData.apiVersion == "1.20"` test passes
- [x] `./gradlew check` passes

## Closes

- Closes #277
- Closes #278
- Closes #279
- Closes #280
- Closes #281