### PR TITLE
fix: SpigotDownloaderTest URL mismatch causing CI failure

### DIFF
--- a/paper/src/test/kotlin/party/morino/mpm/infrastructure/downloader/spigot/SpigotDownloaderTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/infrastructure/downloader/spigot/SpigotDownloaderTest.kt
@@ -58,7 +58,7 @@ class SpigotDownloaderTest {
         val mockEngine =
             MockEngine { request ->
                 when (request.url.toString()) {
-                    "https://api.spiget.org/v2/resources/9089/versions?sort=-name&size=1" -> {
+                    "https://api.spiget.org/v2/resources/9089/versions?sort=-releaseDate&size=1" -> {
                         respond(
                             content = ByteReadChannel(MockDataLoader.Spigot.getLatestVersion()),
                             status = HttpStatusCode.OK,


### PR DESCRIPTION
## Summary

- The mock URL in `SpigotDownloaderTest.getLatestVersion()` used `sort=-name` but the implementation (`SpigotDownloader.kt:68`) was updated to use `sort=-releaseDate` in a prior commit
- This mismatch caused the MockEngine to fall through to the `else` branch and return a 404, failing the test

## Root cause

In commit `5f908fe`, the sort parameter was changed in the implementation but the test mock was not updated to match.

## Test plan

- [x] `SpigotDownloaderTest > getLatestVersion()` now passes locally
- [x] All `SpigotDownloaderTest` tests pass