### PR TITLE
✨ Implement Hangar platform support (fix HANGER typo)

### DIFF
--- a/api/src/main/kotlin/party/morino/mpm/api/domain/downloader/model/RepositoryType.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/domain/downloader/model/RepositoryType.kt
@@ -20,7 +20,7 @@ enum class RepositoryType(
 ) {
     GITHUB("https://github.com"),
     SPIGOTMC("https://www.spigotmc.org"),
-    HANGER("https://hangar.papermc.io"),
+    HANGAR("https://hangar.papermc.io"),
     MODRINTH("https://modrinth.com"),
 
     // unmanagedプラグイン用の不明なリポジトリタイプ

--- a/docs/content/docs/format/repository.mdx
+++ b/docs/content/docs/format/repository.mdx
@@ -110,15 +110,32 @@ SpigotMCリソースからプラグインをダウンロードします。
 - **URL形式**: `https://www.spigotmc.org/resources/{resource-name}.{id}`
 - **API**: Spiget API v2を使用
 
+### Hangar
+
+Hangar（PaperMC公式プラグインリポジトリ）からプラグインをダウンロードします。
+
+```jsonc
+{
+    "type": "hangar",
+    "id": "kennytv/Maintenance" // owner/project 形式（project単体も可）
+}
+```
+
+- **URL形式**: `https://hangar.papermc.io/{owner}/{project}`
+- **API**: Hangar API v1を使用
+- **プラットフォーム選択**: 既定でPAPER向けファイルを優先的にダウンロード（無い場合は他プラットフォームにフォールバック）
+- **チャンネル**: `tag:` 指定でHangarのチャンネル名（`Release`, `Snapshot`, `Beta`, `Alpha`など）を大文字小文字を区別せずフィルタリング
+
 ## フィールド説明
 
 ### 必須フィールド
 
-- **type**: リポジトリタイプ（`modrinth`, `github`, `spigotmc`, `hangar` ⚠️ hangarは未実装）
+- **type**: リポジトリタイプ（`modrinth`, `github`, `spigotmc`, `hangar`）
 - **id**: リポジトリ固有のID
   - GitHub: `owner/repository`
   - SpigotMC: リソースID
   - Modrinth: プロジェクトIDまたはslug
+  - Hangar: `owner/project`（project単体も可）
 
 ### オプショナルフィールド
 

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginInfoServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginInfoServiceImpl.kt
@@ -302,6 +302,15 @@ class PluginInfoServiceImpl :
             }
             "modrinth" -> UrlData.ModrinthUrlData(id = repositoryId)
             "spigotmc" -> UrlData.SpigotMcUrlData(resourceId = repositoryId)
+            "hangar" -> {
+                // Hangar形式: "owner/project"（ownerを省略したslug単体も許容する）
+                val parts = repositoryId.split("/")
+                when (parts.size) {
+                    2 -> UrlData.HangarUrlData(owner = parts[0], projectName = parts[1])
+                    1 -> UrlData.HangarUrlData(owner = "", projectName = parts[0])
+                    else -> null
+                }
+            }
             else -> null
         }
     }

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginLifecycleServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginLifecycleServiceImpl.kt
@@ -335,6 +335,20 @@ class PluginLifecycleServiceImpl :
                 }
                 "modrinth" -> UrlData.ModrinthUrlData(id = repositoryInfo.id)
                 "spigotmc" -> UrlData.SpigotMcUrlData(resourceId = repositoryInfo.id)
+                "hangar" -> {
+                    // Hangar形式: "owner/project"（ownerを省略したslug単体も許容する）
+                    val parts = repositoryInfo.id.split("/")
+                    when (parts.size) {
+                        2 -> UrlData.HangarUrlData(owner = parts[0], projectName = parts[1])
+                        1 -> UrlData.HangarUrlData(owner = "", projectName = parts[0])
+                        else ->
+                            return MpmError.PluginError
+                                .InstallFailed(
+                                    pluginName,
+                                    "Invalid Hangar repository ID format: ${repositoryInfo.id}"
+                                ).left()
+                    }
+                }
                 else -> return MpmError.PluginError.UnsupportedRepository(repositoryInfo.type.name).left()
             }
 
@@ -1099,6 +1113,16 @@ class PluginLifecycleServiceImpl :
                     ?.let { (owner, repository) -> UrlData.GithubUrlData(owner, repository) }
             "modrinth" -> UrlData.ModrinthUrlData(repo.repositoryId)
             "spigotmc" -> UrlData.SpigotMcUrlData(repo.repositoryId)
+            "hangar" ->
+                repo.repositoryId
+                    .split("/")
+                    .let { parts ->
+                        when (parts.size) {
+                            2 -> UrlData.HangarUrlData(owner = parts[0], projectName = parts[1])
+                            1 -> UrlData.HangarUrlData(owner = "", projectName = parts[0])
+                            else -> null
+                        }
+                    }
             else -> null
         }
 

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
@@ -1122,6 +1122,15 @@ class PluginUpdateServiceImpl :
             }
             "modrinth" -> UrlData.ModrinthUrlData(id = repositoryId)
             "spigotmc" -> UrlData.SpigotMcUrlData(resourceId = repositoryId)
+            "hangar" -> {
+                // Hangar形式: "owner/project"（ownerを省略したslug単体も許容する）
+                val parts = repositoryId.split("/")
+                when (parts.size) {
+                    2 -> UrlData.HangarUrlData(owner = parts[0], projectName = parts[1])
+                    1 -> UrlData.HangarUrlData(owner = "", projectName = parts[0])
+                    else -> null
+                }
+            }
             else -> null
         }
     }

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/DownloaderRepositoryImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/DownloaderRepositoryImpl.kt
@@ -18,6 +18,7 @@ import party.morino.mpm.api.domain.downloader.model.RepositoryType
 import party.morino.mpm.api.domain.downloader.model.UrlData
 import party.morino.mpm.api.domain.downloader.model.VersionData
 import party.morino.mpm.infrastructure.downloader.github.GithubDownloader
+import party.morino.mpm.infrastructure.downloader.hangar.HangarDownloader
 import party.morino.mpm.infrastructure.downloader.modrinth.ModrinthDownloader
 import party.morino.mpm.infrastructure.downloader.spigot.SpigotDownloader
 import java.io.File
@@ -39,9 +40,11 @@ class DownloaderRepositoryImpl :
     private val spigotDownloaderLazy = lazy { SpigotDownloader() }
     private val modrinthDownloaderLazy = lazy { ModrinthDownloader() }
     private val githubDownloaderLazy = lazy { createGithubDownloader() }
+    private val hangarDownloaderLazy = lazy { HangarDownloader() }
     private val spigotDownloader: SpigotDownloader by spigotDownloaderLazy
     private val modrinthDownloader: ModrinthDownloader by modrinthDownloaderLazy
     private val githubDownloader: GithubDownloader by githubDownloaderLazy
+    private val hangarDownloader: HangarDownloader by hangarDownloaderLazy
 
     /**
      * GitHubダウンローダーを生成する
@@ -61,7 +64,7 @@ class DownloaderRepositoryImpl :
         when {
             url.startsWith(RepositoryType.GITHUB.url) -> RepositoryType.GITHUB
             url.startsWith(RepositoryType.SPIGOTMC.url) -> RepositoryType.SPIGOTMC
-            url.startsWith(RepositoryType.HANGER.url) -> RepositoryType.HANGER
+            url.startsWith(RepositoryType.HANGAR.url) -> RepositoryType.HANGAR
             url.startsWith(RepositoryType.MODRINTH.url) -> RepositoryType.MODRINTH
             else -> null
         }
@@ -90,7 +93,7 @@ class DownloaderRepositoryImpl :
                 UrlData.SpigotMcUrlData(resId)
             }
 
-            RepositoryType.HANGER -> {
+            RepositoryType.HANGAR -> {
                 val split = formattedUrl.split("/")
                 // パス segment 数が不足している場合はパース不能としてnullを返す
                 if (split.size < 5) return null
@@ -131,6 +134,10 @@ class DownloaderRepositoryImpl :
                 modrinthDownloader.getLatestVersion(urlData)
             }
 
+            is UrlData.HangarUrlData -> {
+                hangarDownloader.getLatestVersion(urlData)
+            }
+
             else -> {
                 // 他のリポジトリタイプの実装
                 throw Exception("未対応のリポジトリタイプです")
@@ -160,6 +167,10 @@ class DownloaderRepositoryImpl :
                 modrinthDownloader.getVersionByName(urlData, versionName)
             }
 
+            is UrlData.HangarUrlData -> {
+                hangarDownloader.getVersionByName(urlData, versionName)
+            }
+
             else -> {
                 // 他のリポジトリタイプの実装
                 throw Exception("未対応のリポジトリタイプです")
@@ -179,6 +190,9 @@ class DownloaderRepositoryImpl :
             }
             is UrlData.GithubUrlData -> {
                 githubDownloader.getLatestVersionByTag(urlData, tag)
+            }
+            is UrlData.HangarUrlData -> {
+                hangarDownloader.getLatestVersionByTag(urlData, tag)
             }
             else -> null
         }
@@ -217,6 +231,10 @@ class DownloaderRepositoryImpl :
                 modrinthDownloader.getAllVersions(urlData)
             }
 
+            is UrlData.HangarUrlData -> {
+                hangarDownloader.getAllVersions(urlData)
+            }
+
             else -> {
                 // 他のリポジトリタイプの実装
                 emptyList()
@@ -246,6 +264,10 @@ class DownloaderRepositoryImpl :
 
             is UrlData.ModrinthUrlData -> {
                 modrinthDownloader.downloadByVersion(urlData, version, fileNamePattern)
+            }
+
+            is UrlData.HangarUrlData -> {
+                hangarDownloader.downloadByVersion(urlData, version, fileNamePattern)
             }
 
             else -> {
@@ -278,9 +300,9 @@ class DownloaderRepositoryImpl :
                 spigotDownloader.downloadByVersion(urlData, latest, fileNamePattern)
             }
 
-            RepositoryType.HANGER -> {
-                // Hangarのダウンロード実装
-                null
+            RepositoryType.HANGAR -> {
+                val latest = hangarDownloader.getLatestVersion(urlData as UrlData.HangarUrlData)
+                hangarDownloader.downloadByVersion(urlData, latest, fileNamePattern)
             }
 
             RepositoryType.MODRINTH -> {
@@ -299,7 +321,7 @@ class DownloaderRepositoryImpl :
      * 1つのクローズ失敗が他のクローズを妨げないようにする
      */
     override fun shutdown() {
-        listOf(spigotDownloaderLazy, modrinthDownloaderLazy, githubDownloaderLazy)
+        listOf(spigotDownloaderLazy, modrinthDownloaderLazy, githubDownloaderLazy, hangarDownloaderLazy)
             .filter { it.isInitialized() }
             .forEach { lazy ->
                 runCatching { lazy.value.close() }

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/HangarDownloader.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/HangarDownloader.kt
@@ -1,0 +1,240 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.downloader.hangar
+
+import party.morino.mpm.api.domain.downloader.model.RepositoryType
+import party.morino.mpm.api.domain.downloader.model.UrlData
+import party.morino.mpm.api.domain.downloader.model.VersionData
+import party.morino.mpm.infrastructure.downloader.AbstractPluginDownloader
+import party.morino.mpm.infrastructure.downloader.hangar.data.HangarVersion
+import party.morino.mpm.infrastructure.downloader.hangar.data.HangarVersionsResponse
+import java.io.File
+
+/**
+ * Hangar（PaperMC公式プラグインリポジトリ）からプラグインをダウンロードするクラス
+ *
+ * Hangar API v1（https://hangar.papermc.io/api-docs）を利用する。
+ * Hangarではバージョン名がそのままバージョン文字列となるため、VersionDataの
+ * downloadIdとversionには同じ値（バージョン名）を格納する。
+ *
+ * テストのためにopenクラスとして定義
+ */
+open class HangarDownloader : AbstractPluginDownloader() {
+    // HangarのURLパターン: https://hangar.papermc.io/{owner}/{project}
+    private val hangarPattern =
+        Regex("https?://hangar\\.papermc\\.io/([^/]+)/([^/]+)(?:/.*)?")
+
+    // Paper向けプラグイン管理のため、ダウンロード時に優先するプラットフォーム
+    private val preferredPlatform = "PAPER"
+
+    // 1ページあたりの取得件数（Hangar APIの上限は25）
+    private val pageSize = 25L
+
+    /**
+     * リポジトリタイプの判定
+     * @param url リポジトリURL
+     * @return リポジトリタイプ、該当なしの場合はnull
+     */
+    override fun getRepositoryType(url: String): RepositoryType? =
+        if (hangarPattern.matches(url)) RepositoryType.HANGAR else null
+
+    /**
+     * URLデータの抽出
+     * @param url リポジトリURL
+     * @return 抽出したURLデータ
+     */
+    override fun getUrlData(url: String): UrlData? {
+        val match = hangarPattern.find(url) ?: return null
+        val owner = match.groupValues[1]
+        val projectName = match.groupValues[2]
+        return UrlData.HangarUrlData(owner, projectName)
+    }
+
+    /**
+     * すべてのバージョンをページネーションで巡回して取得するヘルパー
+     *
+     * Hangar APIはページングされるため、全件取得するには全ページを巡回する必要がある。
+     * @param urlData HangarのURL情報
+     * @return バージョンのリスト（新しい順）
+     */
+    private suspend fun fetchAllVersions(urlData: UrlData.HangarUrlData): List<HangarVersion> {
+        val versions = mutableListOf<HangarVersion>()
+        var offset = 0L
+        while (true) {
+            val url =
+                "https://hangar.papermc.io/api/v1/projects/${urlData.projectName}/versions" +
+                    "?limit=$pageSize&offset=$offset"
+            val response = getRequest(url, "application/json")
+            val page = json.decodeFromString<HangarVersionsResponse>(response)
+            versions.addAll(page.result)
+            // 実際に取得できた件数だけoffsetを進める
+            // （サーバーがpageSize未満に切り詰めても中間バージョンを飛ばさないため）
+            offset += page.result.size
+            // 取得済み件数が全件数に達したか、空ページに到達したら終了
+            if (offset >= page.pagination.count || page.result.isEmpty()) break
+        }
+        return versions
+    }
+
+    /**
+     * 最新バージョンの取得
+     *
+     * チャンネル指定がない場合はReleaseチャンネルを優先する（Beta/Alpha/Snapshotを除外）。
+     * Releaseが存在しない場合はフォールバックとして全バージョンの最新を返す。
+     *
+     * @param urlData HangarのURL情報
+     * @return 最新バージョン
+     */
+    override suspend fun getLatestVersion(urlData: UrlData): VersionData {
+        urlData as UrlData.HangarUrlData
+        val versions = fetchAllVersions(urlData)
+        if (versions.isEmpty()) throw Exception("このプロジェクトにはバージョンがありません")
+
+        // Releaseチャンネルを優先し、無ければ全体の最新にフォールバック
+        val releaseVersions = versions.filter { it.channel.name.equals("Release", ignoreCase = true) }
+        val latest = releaseVersions.firstOrNull() ?: versions[0]
+        return VersionData(downloadId = latest.name, version = latest.name)
+    }
+
+    /**
+     * 指定されたタグ/チャンネルの最新バージョンを取得する
+     *
+     * Hangarのチャンネル名（Release, Snapshot, Beta, Alphaなど）でフィルタリングする。
+     * 大文字小文字は区別しない。
+     *
+     * @param urlData HangarのURL情報
+     * @param tag タグ名（"release", "beta", "alpha", "snapshot"など）
+     * @return 該当タグの最新バージョン、見つからない場合はnull
+     */
+    override suspend fun getLatestVersionByTag(
+        urlData: UrlData,
+        tag: String
+    ): VersionData? {
+        urlData as UrlData.HangarUrlData
+        val versions = fetchAllVersions(urlData)
+
+        // チャンネル名がタグに一致するバージョンをフィルタ（最初の要素が最新）
+        val latest =
+            versions.firstOrNull { it.channel.name.equals(tag, ignoreCase = true) } ?: return null
+        return VersionData(downloadId = latest.name, version = latest.name)
+    }
+
+    /**
+     * 指定されたバージョン名からバージョン情報を取得
+     * @param urlData HangarのURL情報
+     * @param versionName バージョン名
+     * @return バージョン情報
+     */
+    override suspend fun getVersionByName(
+        urlData: UrlData,
+        versionName: String
+    ): VersionData {
+        urlData as UrlData.HangarUrlData
+        val versions = fetchAllVersions(urlData)
+
+        // 指定されたバージョン名に一致するバージョンを探す
+        val matched =
+            versions.firstOrNull { it.name == versionName }
+                ?: throw Exception("バージョン '$versionName' が見つかりませんでした")
+        return VersionData(downloadId = matched.name, version = matched.name)
+    }
+
+    /**
+     * すべてのバージョンを取得
+     * @param urlData HangarのURL情報
+     * @return バージョンリスト（新しい順）
+     */
+    override suspend fun getAllVersions(urlData: UrlData): List<VersionData> {
+        urlData as UrlData.HangarUrlData
+        return fetchAllVersions(urlData).map { VersionData(downloadId = it.name, version = it.name) }
+    }
+
+    /**
+     * 指定バージョンのプラグインをダウンロード
+     *
+     * バージョン詳細を取得し、プラットフォーム別のダウンロードURLからファイルを取得する。
+     * fileNamePatternが指定された場合はファイル名に一致するプラットフォームを選択し、
+     * 未指定の場合はPAPERを優先する。
+     *
+     * @param urlData HangarのURL情報
+     * @param version バージョン（downloadIdにバージョン名が入る）
+     * @param fileNamePattern ファイル名に一致する正規表現パターン（複数プラットフォームがある場合の選択に使用）
+     * @return ダウンロードしたファイル
+     */
+    override suspend fun downloadByVersion(
+        urlData: UrlData,
+        version: VersionData,
+        fileNamePattern: String?
+    ): File? {
+        urlData as UrlData.HangarUrlData
+        // バージョン名からバージョン詳細を取得
+        val url = "https://hangar.papermc.io/api/v1/projects/${urlData.projectName}/versions/${version.downloadId}"
+        val response = getRequest(url, "application/json")
+        val versionInfo = json.decodeFromString<HangarVersion>(response)
+
+        // ダウンロード可能なプラットフォームを選択（url, fileName）
+        val (downloadUrl, fileName) = selectDownload(versionInfo, fileNamePattern)
+        return downloadFile(downloadUrl, fileName)
+    }
+
+    /**
+     * ダウンロード対象のプラットフォームを選択し、URLとファイル名を返す
+     *
+     * @param version バージョン情報
+     * @param fileNamePattern ファイル名に一致する正規表現パターン（オプション）
+     * @return ダウンロードURLとファイル名のペア
+     */
+    private fun selectDownload(
+        version: HangarVersion,
+        fileNamePattern: String?
+    ): Pair<String, String> {
+        // ダウンロードURL（Hangarホスト優先、無ければ外部URL）を解決するヘルパー
+        fun resolveUrl(platform: String) = version.downloads[platform]?.let { it.downloadUrl ?: it.externalUrl }
+
+        val chosenPlatform =
+            if (fileNamePattern != null) {
+                // パターンにマッチするファイル名を持つプラットフォームを選択
+                val regex = Regex(fileNamePattern)
+                version.downloads.entries
+                    .firstOrNull { (platform, download) ->
+                        download.fileInfo?.name?.let { regex.matches(it) } == true && resolveUrl(platform) != null
+                    }?.key
+                    ?: throw Exception("パターン '$fileNamePattern' にマッチするファイルが見つかりません")
+            } else {
+                // PAPERを優先し、無ければダウンロード可能な最初のプラットフォーム
+                version.downloads.keys.firstOrNull { it == preferredPlatform && resolveUrl(it) != null }
+                    ?: version.downloads.keys.firstOrNull { resolveUrl(it) != null }
+                    ?: throw Exception("このバージョンにはダウンロード可能なファイルがありません")
+            }
+
+        val download = version.downloads.getValue(chosenPlatform)
+        val downloadUrl =
+            download.downloadUrl ?: download.externalUrl
+                ?: throw Exception("ダウンロードURLが見つかりません")
+        // ファイル名はfileInfoから、無ければバージョン名から生成
+        val fileName = download.fileInfo?.name ?: "${version.name}.jar"
+        return downloadUrl to fileName
+    }
+
+    /**
+     * リポジトリURLからプラグインをダウンロード
+     * @param url リポジトリURL
+     * @param fileNamePattern ファイル名に一致する正規表現パターン（オプション）
+     * @return ダウンロードしたファイル
+     */
+    override suspend fun downloadLatest(
+        url: String,
+        fileNamePattern: String?
+    ): File? {
+        val urlData = getUrlData(url) ?: throw Exception("無効なHangar URL: $url")
+        val latestVersion = getLatestVersion(urlData)
+        return downloadByVersion(urlData, latestVersion, fileNamePattern)
+    }
+}

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarChannel.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarChannel.kt
@@ -1,0 +1,21 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.downloader.hangar.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Hangarのリリースチャンネル情報
+ * @param name チャンネル名（"Release", "Snapshot", "Beta", "Alpha"など）。タグ指定でのフィルタに使用
+ */
+@Serializable
+data class HangarChannel(
+    val name: String
+)

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarFileInfo.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarFileInfo.kt
@@ -1,0 +1,25 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.downloader.hangar.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Hangarのファイル情報
+ * @param name ファイル名（ダウンロード後のファイル名に使用）
+ * @param sizeBytes ファイルサイズ（バイト）
+ * @param sha256Hash SHA-256ハッシュ（Hangarはsha1を提供しないため、現状ハッシュ検証には未使用）
+ */
+@Serializable
+data class HangarFileInfo(
+    val name: String,
+    val sizeBytes: Long = 0,
+    val sha256Hash: String? = null
+)

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarPagination.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarPagination.kt
@@ -1,0 +1,25 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.downloader.hangar.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Hangar APIのページネーション情報
+ * @param limit 1ページあたりの取得件数
+ * @param offset 取得開始位置
+ * @param count 全件数（全ページを巡回する終了判定に使用）
+ */
+@Serializable
+data class HangarPagination(
+    val limit: Long,
+    val offset: Long,
+    val count: Long
+)

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarPlatformDownload.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarPlatformDownload.kt
@@ -1,0 +1,27 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.downloader.hangar.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Hangarのプラットフォーム別ダウンロード情報
+ *
+ * Hangar上でホストされる場合は`downloadUrl`が、外部サイトでホストされる場合は`externalUrl`が設定される。
+ * @param fileInfo ファイル情報（ファイル名やハッシュ）。外部ホストの場合はnull
+ * @param externalUrl 外部ホストのダウンロードURL（Hangar外でホストされる場合）
+ * @param downloadUrl Hangar上のダウンロードURL
+ */
+@Serializable
+data class HangarPlatformDownload(
+    val fileInfo: HangarFileInfo? = null,
+    val externalUrl: String? = null,
+    val downloadUrl: String? = null
+)

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarVersion.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarVersion.kt
@@ -1,0 +1,27 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.downloader.hangar.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Hangarのバージョン情報
+ *
+ * Hangarではバージョン名がそのままバージョン文字列となる（例: "5.1.0"）。
+ * @param name バージョン名（バージョン文字列としても使用）
+ * @param channel リリースチャンネル（"Release", "Snapshot", "Beta", "Alpha"など）
+ * @param downloads プラットフォーム別のダウンロード情報（キー: "PAPER", "WATERFALL", "VELOCITY"）
+ */
+@Serializable
+data class HangarVersion(
+    val name: String,
+    val channel: HangarChannel,
+    val downloads: Map<String, HangarPlatformDownload> = emptyMap()
+)

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarVersionsResponse.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/hangar/data/HangarVersionsResponse.kt
@@ -1,0 +1,25 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.downloader.hangar.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Hangarのバージョン一覧APIのレスポンス
+ *
+ * example: https://hangar.papermc.io/api/v1/projects/{slug}/versions
+ * @param pagination ページネーション情報（全件数の把握に使用）
+ * @param result バージョンのリスト（新しい順）
+ */
+@Serializable
+data class HangarVersionsResponse(
+    val pagination: HangarPagination,
+    val result: List<HangarVersion>
+)

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/spigot/SpigotDownloader.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/downloader/spigot/SpigotDownloader.kt
@@ -97,7 +97,11 @@ open class SpigotDownloader : AbstractPluginDownloader() {
             versions.firstOrNull { it.name == versionName }
                 ?: throw Exception("バージョン '$versionName' が見つかりませんでした")
 
-        return VersionData(downloadId = matchedVersion.id?.toString() ?: "unknown", version = matchedVersion.name ?: "unknown")
+        return VersionData(
+            downloadId = matchedVersion.id?.toString() ?: "unknown",
+            version =
+                matchedVersion.name ?: "unknown"
+        )
     }
 
     /**

--- a/paper/src/test/kotlin/party/morino/mpm/infrastructure/downloader/hangar/HangarDownloaderTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/infrastructure/downloader/hangar/HangarDownloaderTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.downloader.hangar
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import party.morino.mpm.api.domain.downloader.model.RepositoryType
+import party.morino.mpm.api.domain.downloader.model.UrlData
+import party.morino.mpm.api.domain.downloader.model.VersionData
+
+class HangarDownloaderTest {
+    // テスト用のHangarDownloaderインスタンス
+    private val downloader = HangarDownloader()
+
+    /**
+     * バージョン一覧APIをモックするダウンローダーを生成する
+     */
+    private fun versionsMockDownloader(): HangarDownloader {
+        val mockEngine =
+            MockEngine { request ->
+                when {
+                    // 単一バージョン取得（/versions/{name}）を先に判定する
+                    Regex(".*/versions/[^?]+$").matches(request.url.encodedPath) -> {
+                        respond(
+                            content =
+                                ByteReadChannel(
+                                    party.morino.mpm.utils.MockDataLoader.Hangar
+                                        .getVersionDetail()
+                                ),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                        )
+                    }
+
+                    request.url.encodedPath.endsWith("/versions") -> {
+                        respond(
+                            content =
+                                ByteReadChannel(
+                                    party.morino.mpm.utils.MockDataLoader.Hangar
+                                        .getProjectVersions()
+                                ),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                        )
+                    }
+
+                    else -> respond(content = ByteReadChannel(""), status = HttpStatusCode.NotFound)
+                }
+            }
+        return object : HangarDownloader() {
+            init {
+                httpClient = HttpClient(mockEngine)
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("recognizes Hangar URL")
+    fun getRepositoryType() {
+        // HangarのURLが正しく認識されることをテスト
+        val validUrl = "https://hangar.papermc.io/kennytv/Maintenance"
+        assertEquals(RepositoryType.HANGAR, downloader.getRepositoryType(validUrl))
+
+        // 無効なURLがnullを返すことをテスト
+        assertNull(downloader.getRepositoryType("https://example.com/kennytv/Maintenance"))
+    }
+
+    @Test
+    @DisplayName("extracts owner and project from URL")
+    fun getUrlData() {
+        val urlData = downloader.getUrlData("https://hangar.papermc.io/kennytv/Maintenance")
+
+        assertNotNull(urlData)
+        assertTrue(urlData is UrlData.HangarUrlData)
+        val hangarUrlData = urlData as UrlData.HangarUrlData
+        assertEquals("kennytv", hangarUrlData.owner)
+        assertEquals("Maintenance", hangarUrlData.projectName)
+    }
+
+    @Test
+    @DisplayName("latest version prefers Release channel")
+    fun getLatestVersion() {
+        val testDownloader = versionsMockDownloader()
+
+        runBlocking {
+            val urlData = UrlData.HangarUrlData("kennytv", "Maintenance")
+            val versionData = testDownloader.getLatestVersion(urlData)
+
+            // Betaを飛ばして最新のReleaseが選択される
+            assertEquals("5.1.0", versionData.version)
+            assertEquals("5.1.0", versionData.downloadId)
+        }
+    }
+
+    @Test
+    @DisplayName("tag filter selects matching channel")
+    fun getLatestVersionByTag() {
+        val testDownloader = versionsMockDownloader()
+
+        runBlocking {
+            val urlData = UrlData.HangarUrlData("kennytv", "Maintenance")
+
+            // betaチャンネルの最新を取得
+            val beta = testDownloader.getLatestVersionByTag(urlData, "beta")
+            assertEquals("5.0.0-beta.2", beta?.version)
+
+            // 存在しないチャンネルはnull
+            assertNull(testDownloader.getLatestVersionByTag(urlData, "nonexistent"))
+        }
+    }
+
+    @Test
+    @DisplayName("getAllVersions returns every version")
+    fun getAllVersions() {
+        val testDownloader = versionsMockDownloader()
+
+        runBlocking {
+            val urlData = UrlData.HangarUrlData("kennytv", "Maintenance")
+            val versions = testDownloader.getAllVersions(urlData)
+
+            assertEquals(3, versions.size)
+            assertEquals("5.1.0", versions[0].version)
+        }
+    }
+
+    @Test
+    @DisplayName("downloadByVersion prefers PAPER platform")
+    fun downloadByVersion() {
+        val testDownloader =
+            object : HangarDownloader() {
+                init {
+                    httpClient =
+                        HttpClient(
+                            MockEngine { request ->
+                                when {
+                                    request.url.toString().contains("/versions/5.1.0") &&
+                                        request.url.host == "hangar.papermc.io" -> {
+                                        respond(
+                                            content =
+                                                ByteReadChannel(
+                                                    party.morino.mpm.utils.MockDataLoader.Hangar
+                                                        .getVersionDetail()
+                                                ),
+                                            status = HttpStatusCode.OK,
+                                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                        )
+                                    }
+
+                                    request.url.host == "hangarcdn.papermc.io" -> {
+                                        respond(
+                                            content = ByteReadChannel(ByteArray(100)),
+                                            status = HttpStatusCode.OK,
+                                            headers = headersOf(HttpHeaders.ContentType, "application/java-archive")
+                                        )
+                                    }
+
+                                    else -> respond(content = ByteReadChannel(""), status = HttpStatusCode.NotFound)
+                                }
+                            }
+                        )
+                }
+            }
+
+        runBlocking {
+            val urlData = UrlData.HangarUrlData("kennytv", "Maintenance")
+            val version = VersionData("5.1.0", "5.1.0")
+            val file = testDownloader.downloadByVersion(urlData, version, null)
+
+            assertNotNull(file)
+            assertTrue(file!!.exists())
+            file.delete()
+        }
+    }
+
+    @Test
+    @DisplayName("getVersionByName throws when not found")
+    fun getVersionByNameNotFound() {
+        val testDownloader = versionsMockDownloader()
+
+        assertThrows<Exception> {
+            runBlocking {
+                val urlData = UrlData.HangarUrlData("kennytv", "Maintenance")
+                testDownloader.getVersionByName(urlData, "9.9.9")
+            }
+        }
+    }
+}

--- a/paper/src/test/kotlin/party/morino/mpm/utils/MockDataLoader.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/utils/MockDataLoader.kt
@@ -79,6 +79,21 @@ object MockDataLoader {
     }
 
     /**
+     * Hangar APIのmockデータを読み込む
+     */
+    object Hangar {
+        /**
+         * https://hangar.papermc.io/api/v1/projects/{slug}/versions のレスポンスを取得
+         */
+        fun getProjectVersions(): String = loadMockData("mock/http/hangar/versions.json")
+
+        /**
+         * https://hangar.papermc.io/api/v1/projects/{slug}/versions/{name} のレスポンスを取得
+         */
+        fun getVersionDetail(): String = loadMockData("mock/http/hangar/version-detail.json")
+    }
+
+    /**
      * Repository関連のmockデータを読み込む
      */
     object Repository {

--- a/paper/src/test/resources/mock/http/hangar/version-detail.json
+++ b/paper/src/test/resources/mock/http/hangar/version-detail.json
@@ -1,0 +1,24 @@
+{
+  "name": "5.1.0",
+  "channel": { "name": "Release" },
+  "downloads": {
+    "PAPER": {
+      "fileInfo": {
+        "name": "Maintenance-Paper-5.1.0.jar",
+        "sizeBytes": 233744,
+        "sha256Hash": "ab08939d28b3ef1a68aa9194092652282cc3405f7fcf7cbb059a74c58f1dcba7"
+      },
+      "externalUrl": null,
+      "downloadUrl": "https://hangarcdn.papermc.io/plugins/kennytv/Maintenance/versions/5.1.0/PAPER/Maintenance-Paper-5.1.0.jar"
+    },
+    "WATERFALL": {
+      "fileInfo": {
+        "name": "Maintenance-Bungee-5.1.0.jar",
+        "sizeBytes": 2899775,
+        "sha256Hash": "fc4e95f6293de16938fefa92076478d2f98c2412727f00f8520673b0bd0a9bef"
+      },
+      "externalUrl": null,
+      "downloadUrl": "https://hangarcdn.papermc.io/plugins/kennytv/Maintenance/versions/5.1.0/WATERFALL/Maintenance-Bungee-5.1.0.jar"
+    }
+  }
+}

--- a/paper/src/test/resources/mock/http/hangar/versions.json
+++ b/paper/src/test/resources/mock/http/hangar/versions.json
@@ -1,0 +1,54 @@
+{
+  "pagination": {
+    "limit": 25,
+    "offset": 0,
+    "count": 3
+  },
+  "result": [
+    {
+      "name": "5.1.0",
+      "channel": { "name": "Release" },
+      "downloads": {
+        "PAPER": {
+          "fileInfo": {
+            "name": "Maintenance-Paper-5.1.0.jar",
+            "sizeBytes": 233744,
+            "sha256Hash": "ab08939d28b3ef1a68aa9194092652282cc3405f7fcf7cbb059a74c58f1dcba7"
+          },
+          "externalUrl": null,
+          "downloadUrl": "https://hangarcdn.papermc.io/plugins/kennytv/Maintenance/versions/5.1.0/PAPER/Maintenance-Paper-5.1.0.jar"
+        }
+      }
+    },
+    {
+      "name": "5.0.0-beta.2",
+      "channel": { "name": "Beta" },
+      "downloads": {
+        "PAPER": {
+          "fileInfo": {
+            "name": "Maintenance-Paper-5.0.0-beta.2.jar",
+            "sizeBytes": 233000,
+            "sha256Hash": "0000000000000000000000000000000000000000000000000000000000000000"
+          },
+          "externalUrl": null,
+          "downloadUrl": "https://hangarcdn.papermc.io/plugins/kennytv/Maintenance/versions/5.0.0-beta.2/PAPER/Maintenance-Paper-5.0.0-beta.2.jar"
+        }
+      }
+    },
+    {
+      "name": "4.3.0",
+      "channel": { "name": "Release" },
+      "downloads": {
+        "PAPER": {
+          "fileInfo": {
+            "name": "Maintenance-Paper-4.3.0.jar",
+            "sizeBytes": 230000,
+            "sha256Hash": "1111111111111111111111111111111111111111111111111111111111111111"
+          },
+          "externalUrl": null,
+          "downloadUrl": "https://hangarcdn.papermc.io/plugins/kennytv/Maintenance/versions/4.3.0/PAPER/Maintenance-Paper-4.3.0.jar"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements Hangar (PaperMC's official plugin repository) support, which was previously advertised in the docs but non-functional. Fixes the `HANGER` → `HANGAR` enum typo and adds a working `HangarDownloader` backed by the [Hangar API v1](https://hangar.papermc.io/api-docs).

Closes #238
Closes #172

## Changes

- **Fix typo**: `RepositoryType.HANGER` → `RepositoryType.HANGAR` (breaking for any config strings using the old spelling — none were reachable before since Hangar returned `null`).
- **`HangarDownloader`** (`infrastructure/downloader/hangar/`):
  - Paginated version listing via `/api/v1/projects/{slug}/versions`
  - `getLatestVersion` prefers the `Release` channel, falling back to the newest version (mirrors `ModrinthDownloader`)
  - `getLatestVersionByTag` filters by Hangar channel name (`Release`/`Beta`/`Alpha`/`Snapshot`), case-insensitive
  - `getVersionByName`, `getAllVersions`
  - `downloadByVersion` prefers the `PAPER` platform artifact, falls back to any available (Hangar-hosted `downloadUrl` or `externalUrl`), and honours `fileNameRegex`
  - New per-class data models (`HangarVersion`, `HangarChannel`, `HangarPlatformDownload`, `HangarFileInfo`, `HangarPagination`, `HangarVersionsResponse`)
- **Wiring** in `DownloaderRepositoryImpl`: `HangarUrlData` handled in every dispatch path plus `shutdown()`.
- **`createUrlData`** "hangar" branch added to `PluginInfoServiceImpl`, `PluginUpdateServiceImpl`, and both sites in `PluginLifecycleServiceImpl`. Repository id is `owner/project` (a bare project slug is also tolerated; only the slug is needed for the API).
- **Tests**: `HangarDownloaderTest` with mock API fixtures under `test/resources/mock/http/hangar/`.
- **Docs**: Hangar section added to `docs/format/repository.mdx`.

## Notes / limitations

- Hangar exposes `sha256`, but the download verifier currently only checks `sha1`, so hash verification is skipped for Hangar installs (same behaviour as SpigotMC/GitHub). Left for a follow-up if sha256 verification is desired.

## Testing

- `task check` (format + build) passes.
- `:paper:test` — 108 tests, 0 failures (7 new Hangar tests).