### PR TITLE
📌 Implement `mpm-lock.yaml` with lockfile-driven install (`--frozen`)

### DIFF
--- a/api/src/main/kotlin/party/morino/mpm/api/application/lock/LockService.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/application/lock/LockService.kt
@@ -1,0 +1,39 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.api.application.lock
+
+import arrow.core.Either
+import party.morino.mpm.api.domain.project.lock.MpmLock
+import party.morino.mpm.api.shared.error.MpmError
+
+/**
+ * ロックファイル（mpm-lock.yaml）の生成・取得を担当するサービス
+ *
+ * 管理下プラグインのメタデータを集約してロックファイルを再生成する。
+ * install/update/add などの状態変更後に呼び出すことで、ロックファイルを
+ * 実際のインストール状態に追従させる。
+ */
+interface LockService {
+    /**
+     * 管理下プラグインのメタデータからロックファイルを再生成して保存する
+     *
+     * @return 生成したロック内容、失敗時はエラー
+     */
+    suspend fun regenerate(): Either<MpmError, MpmLock>
+
+    /**
+     * 現在のロックファイルを取得する
+     *
+     * @return ロック内容、存在しない場合はnull
+     */
+    suspend fun find(): MpmLock?
+}

--- a/api/src/main/kotlin/party/morino/mpm/api/application/plugin/PluginUpdateService.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/application/plugin/PluginUpdateService.kt
@@ -59,11 +59,14 @@ interface PluginUpdateService {
      *
      * @param force trueの場合、api-version非互換でも強制インストールする
      * @param skipIntegrity trueの場合、整合性検証の不一致を無視してインストールを続行する
+     * @param frozen trueの場合、mpm-lock.yamlに記録された正確なバージョンをインストールする
+     *   （mpm.jsonのlatest/tag指定を無視した再現インストール。ロック未存在時はエラー）
      * @return 一括インストール結果
      */
     suspend fun installAll(
         force: Boolean = false,
-        skipIntegrity: Boolean = false
+        skipIntegrity: Boolean = false,
+        frozen: Boolean = false
     ): Either<MpmError, BulkInstallResult>
 
     /**

--- a/api/src/main/kotlin/party/morino/mpm/api/domain/project/lock/LockEntry.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/domain/project/lock/LockEntry.kt
@@ -1,0 +1,37 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.api.domain.project.lock
+
+import kotlinx.serialization.Serializable
+import party.morino.mpm.api.domain.plugin.dto.MetadataDownloadInfoDto
+import party.morino.mpm.api.domain.plugin.dto.RepositoryInfo
+import party.morino.mpm.api.domain.plugin.dto.version.VersionDetailDto
+
+/**
+ * ロックファイル（mpm-lock.yaml）の1プラグイン分のエントリ
+ *
+ * 実際にインストールされたプラグインの正確なバージョン・ダウンロード情報を記録し、
+ * 別環境での再現可能なインストールを可能にする。フィールド構成はmetadataの
+ * 各yamlファイルのサブセットで、既存のDTOを再利用する。
+ *
+ * @param version バージョン情報（raw/normalized）
+ * @param download ダウンロード情報（url/downloadId/fileName/sha256）
+ * @param repository 取得元リポジトリ（type/id）
+ * @param installedAt インストール日時（ISO 8601形式）
+ */
+@Serializable
+data class LockEntry(
+    val version: VersionDetailDto,
+    val download: MetadataDownloadInfoDto,
+    val repository: RepositoryInfo,
+    val installedAt: String
+)

--- a/api/src/main/kotlin/party/morino/mpm/api/domain/project/lock/LockRepository.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/domain/project/lock/LockRepository.kt
@@ -1,0 +1,36 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.api.domain.project.lock
+
+/**
+ * ロックファイル（mpm-lock.yaml）の読み書きを担当するリポジトリ
+ */
+interface LockRepository {
+    /**
+     * ロックファイルを読み込む
+     *
+     * @return ロックファイルの内容、存在しない/パース失敗の場合はnull
+     */
+    suspend fun find(): MpmLock?
+
+    /**
+     * ロックファイルを保存する（アトミック書き込み）
+     *
+     * @param lock 保存するロック内容
+     */
+    suspend fun save(lock: MpmLock)
+
+    /**
+     * ロックファイルが存在するかどうかを確認する
+     */
+    suspend fun exists(): Boolean
+}

--- a/api/src/main/kotlin/party/morino/mpm/api/domain/project/lock/MpmLock.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/domain/project/lock/MpmLock.kt
@@ -1,0 +1,37 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.api.domain.project.lock
+
+import kotlinx.serialization.Serializable
+
+/**
+ * mpmのロックファイル（mpm-lock.yaml）
+ *
+ * npmの`package-lock.json`に相当し、実際にインストールされたプラグインの正確な
+ * バージョンとダウンロード情報を記録する。`mpm install --frozen` はこのファイルの
+ * 内容どおりにインストールすることで、環境をまたいだ再現性を保証する。
+ *
+ * @param lockfileVersion ロックファイルのフォーマットバージョン（互換性判定用）
+ * @param generatedAt 生成日時（ISO 8601形式）
+ * @param plugins プラグイン名 → ロックエントリのマップ
+ */
+@Serializable
+data class MpmLock(
+    val lockfileVersion: String,
+    val generatedAt: String,
+    val plugins: Map<String, LockEntry>
+) {
+    companion object {
+        /** 現在のロックファイルフォーマットバージョン */
+        const val CURRENT_LOCKFILE_VERSION: String = "1.0"
+    }
+}

--- a/docs/content/docs/format/mpm-lock.mdx
+++ b/docs/content/docs/format/mpm-lock.mdx
@@ -7,13 +7,12 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 ## 概要
 
-<Callout type="warn" title="⚠️ 未実装機能">
-mpm-lock.yamlは現在未実装です。この仕様は将来のバージョンで実装される予定です。
-現在はmetadata/*.yamlファイルが同等の役割を果たしています。
-</Callout>
-
 `mpm-lock.yaml`は、mpmのロックファイルです。
 npmの`package-lock.json`に相当し、実際にインストールされたプラグインの正確なバージョンとダウンロード情報を記録します。
+
+<Callout type="info" title="自動生成">
+`mpm-lock.yaml`は自動生成・自動更新されます。`mpm install` / `mpm update` / `mpm add` / `mpm remove` / `mpm uninstall` の実行後に、実際のインストール状態を反映して再生成されます。手動で編集する必要はありません。
+</Callout>
 
 ## ファイルの配置
 
@@ -262,11 +261,19 @@ plugins:
 ### 再現可能なインストール
 
 `mpm-lock.yaml`があることで、別の環境で全く同じバージョンのプラグインをインストールできます。
+`--frozen` フラグを付けると、`mpm.json`で`version: latest`等を指定していても、
+ロックファイルに記録された正確なバージョンのみをインストールします（npmの`npm ci`に相当）。
 
 ```bash
-# 他の環境で同じプラグインをインストール
-mpm install
+# ロックファイルどおりの正確なバージョンで再現インストール
+mpm install --frozen
 ```
+
+<Callout type="info" title="ドリフト検出">
+`--frozen` 実行時、`mpm.json`で管理されているプラグインがロックファイルに記録されていない場合（ドリフト）は、そのプラグインを失敗として報告します。ロックファイルを最新化するには、通常の `mpm install` を実行してください。
+</Callout>
+
+`--frozen` を付けない通常の `mpm install` は、`mpm.json`のバージョン指定を解決してインストールし、その結果でロックファイルを更新します。
 
 ### バージョンの固定
 

--- a/paper/src/main/kotlin/party/morino/mpm/Mpm.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/Mpm.kt
@@ -15,6 +15,7 @@ import org.koin.core.context.GlobalContext
 import org.koin.dsl.module
 import party.morino.mpm.api.MpmAPI
 import party.morino.mpm.api.application.dependency.DependencyService
+import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.IntegrityVerifier
 import party.morino.mpm.api.application.plugin.PluginInfoService
 import party.morino.mpm.api.application.plugin.PluginLifecycleService
@@ -30,12 +31,14 @@ import party.morino.mpm.api.domain.dependency.DependencyAnalyzer
 import party.morino.mpm.api.domain.downloader.DownloaderRepository
 import party.morino.mpm.api.domain.plugin.model.VersionSpecifier
 import party.morino.mpm.api.domain.plugin.service.PluginMetadataManager
+import party.morino.mpm.api.domain.project.lock.LockRepository
 import party.morino.mpm.api.domain.project.repository.ProjectRepository
 import party.morino.mpm.api.domain.repository.RepositoryManager
 import party.morino.mpm.api.domain.webhook.WebhookNotifier
 import party.morino.mpm.api.model.plugin.InstalledPlugin
 import party.morino.mpm.api.model.plugin.RepositoryPlugin
 import party.morino.mpm.application.dependency.DependencyServiceImpl
+import party.morino.mpm.application.lock.LockServiceImpl
 import party.morino.mpm.application.plugin.IntegrityVerifierImpl
 import party.morino.mpm.application.plugin.PluginInfoServiceImpl
 import party.morino.mpm.application.plugin.PluginInstallValidator
@@ -52,6 +55,7 @@ import party.morino.mpm.infrastructure.config.PluginDirectoryImpl
 import party.morino.mpm.infrastructure.dependency.DependencyAnalyzerImpl
 import party.morino.mpm.infrastructure.downloader.DownloaderRepositoryImpl
 import party.morino.mpm.infrastructure.mineauth.MineAuthIntegration
+import party.morino.mpm.infrastructure.persistence.LockRepositoryImpl
 import party.morino.mpm.infrastructure.persistence.ProjectRepositoryImpl
 import party.morino.mpm.infrastructure.plugin.service.PluginMetadataManagerImpl
 import party.morino.mpm.infrastructure.repository.RepositorySourceManagerFactory
@@ -207,6 +211,7 @@ open class Mpm :
                 // リポジトリの登録（依存性はKoinのinjectによって自動注入される）
                 single<DownloaderRepository> { DownloaderRepositoryImpl() }
                 single<ProjectRepository> { ProjectRepositoryImpl() }
+                single<LockRepository> { LockRepositoryImpl() }
 
                 // メタデータマネージャーの登録（依存性はKoinのinjectによって自動注入される）
                 single<PluginMetadataManager> { PluginMetadataManagerImpl() }
@@ -228,6 +233,8 @@ open class Mpm :
                 single<PluginInfoService> { PluginInfoServiceImpl() }
                 // リポジトリ横断検索
                 single<PluginSearchService> { PluginSearchServiceImpl() }
+                // ロックファイル（mpm-lock.yaml）管理
+                single<LockService> { LockServiceImpl() }
                 // インストール前検証（APIバージョン互換性・依存関係）の共通ロジック
                 // PluginLifecycleServiceImplとPluginUpdateServiceImplの両方から利用される
                 single { PluginInstallValidator() }

--- a/paper/src/main/kotlin/party/morino/mpm/application/lock/LockServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/lock/LockServiceImpl.kt
@@ -1,0 +1,96 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.application.lock
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import party.morino.mpm.api.application.lock.LockService
+import party.morino.mpm.api.domain.plugin.model.PluginSpec
+import party.morino.mpm.api.domain.plugin.service.PluginMetadataManager
+import party.morino.mpm.api.domain.project.lock.LockEntry
+import party.morino.mpm.api.domain.project.lock.LockRepository
+import party.morino.mpm.api.domain.project.lock.MpmLock
+import party.morino.mpm.api.domain.project.repository.ProjectRepository
+import party.morino.mpm.api.shared.error.MpmError
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * [LockService] の実装
+ *
+ * mpm.jsonの管理下プラグイン一覧と各プラグインのメタデータを突き合わせて
+ * ロックファイルを再生成する。
+ */
+class LockServiceImpl :
+    LockService,
+    KoinComponent {
+    // Koinによる依存性注入
+    private val projectRepository: ProjectRepository by inject()
+    private val metadataManager: PluginMetadataManager by inject()
+    private val lockRepository: LockRepository by inject()
+
+    override suspend fun regenerate(): Either<MpmError, MpmLock> {
+        // プロジェクト（mpm.json）を取得。未初期化ならエラー
+        val project =
+            projectRepository.find()
+                ?: return MpmError.ProjectError.NotInitialized.left()
+
+        val now = Instant.now().truncatedTo(ChronoUnit.SECONDS).toString()
+
+        // 管理下（unmanaged以外）のプラグインを名前順に処理して決定的な出力にする
+        val entries =
+            project.plugins
+                .filterValues { it !is PluginSpec.Unmanaged }
+                .keys
+                .sortedBy { it.value }
+                .mapNotNull { pluginName ->
+                    // メタデータが読めないプラグインはロックに含めない（不完全なエントリを避ける）
+                    val metadata =
+                        metadataManager.loadMetadata(pluginName.value).getOrNull()
+                            ?: return@mapNotNull null
+                    val mpmInfo = metadata.mpmInfo
+                    // fileNameが無いプラグインは、add直後にinstallが失敗した等で実インストールが
+                    // 完了していない状態のため、ロックには含めない（不完全なエントリを避ける）
+                    if (mpmInfo.download.fileName == null) {
+                        return@mapNotNull null
+                    }
+                    // インストール日時は履歴の最新エントリを優先し、無ければ生成時刻を使う
+                    val installedAt = mpmInfo.history.lastOrNull()?.installedAt ?: now
+                    pluginName.value to
+                        LockEntry(
+                            version = mpmInfo.version.current,
+                            download = mpmInfo.download,
+                            repository = mpmInfo.repository,
+                            installedAt = installedAt
+                        )
+                }.toMap()
+
+        val lock =
+            MpmLock(
+                lockfileVersion = MpmLock.CURRENT_LOCKFILE_VERSION,
+                generatedAt = now,
+                plugins = entries
+            )
+
+        return try {
+            lockRepository.save(lock)
+            lock.right()
+        } catch (e: Exception) {
+            MpmError.ProjectError.SaveFailed("ロックファイルの保存に失敗しました: ${e.message}").left()
+        }
+    }
+
+    override suspend fun find(): MpmLock? = lockRepository.find()
+}

--- a/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/plugin/PluginUpdateServiceImpl.kt
@@ -43,6 +43,7 @@ import party.morino.mpm.api.domain.project.dto.MpmConfig
 import party.morino.mpm.api.domain.project.dto.getPluginsSyncingTo
 import party.morino.mpm.api.domain.project.dto.topologicalSortPlugins
 import party.morino.mpm.api.domain.project.dto.validateSyncDependencies
+import party.morino.mpm.api.domain.project.lock.LockRepository
 import party.morino.mpm.api.domain.project.repository.ProjectRepository
 import party.morino.mpm.api.domain.repository.RepositoryManager
 import party.morino.mpm.api.model.backup.BackupReason
@@ -86,6 +87,9 @@ class PluginUpdateServiceImpl :
 
     // ダウンロードしたJARのハッシュ整合性検証を行う
     private val integrityVerifier: IntegrityVerifier by inject()
+
+    // ロックファイル（mpm-lock.yaml）の読み込み（frozenインストールで使用）
+    private val lockRepository: LockRepository by inject()
 
     // 並行更新を防止するためのMutex（スケジューラーとコマンドの競合回避）
     private val updateMutex = Mutex()
@@ -379,17 +383,93 @@ class PluginUpdateServiceImpl :
      */
     override suspend fun installAll(
         force: Boolean,
-        skipIntegrity: Boolean
+        skipIntegrity: Boolean,
+        frozen: Boolean
     ): Either<MpmError, BulkInstallResult> {
         // 並行更新を防止（jar/metadataファイルの競合回避）
         if (!updateMutex.tryLock()) {
             return MpmError.PluginError.UpdateInProgress.left()
         }
         try {
-            return executeInstallAll(force, skipIntegrity)
+            // frozen指定時はロックファイルどおりの正確なバージョンをインストールする
+            return if (frozen) {
+                executeFrozenInstall(force, skipIntegrity)
+            } else {
+                executeInstallAll(force, skipIntegrity)
+            }
         } finally {
             updateMutex.unlock()
         }
+    }
+
+    /**
+     * mpm-lock.yaml に記録された正確なバージョンをインストールする（再現インストール / npm ci 相当）
+     *
+     * mpm.jsonのlatest/tag指定は無視し、ロックファイルのバージョンをそのまま導入する。
+     * ロックファイルが存在しない場合、および管理下プラグインがロックに含まれていない場合（ドリフト）は
+     * エラーとして扱う。
+     */
+    private suspend fun executeFrozenInstall(
+        force: Boolean,
+        skipIntegrity: Boolean
+    ): Either<MpmError, BulkInstallResult> {
+        // ロックファイルを読み込む。未存在と破損を区別する
+        // （破損時に 'mpm install' を促すと再生成で上書きされ再現性が失われるため、明確に区別する）
+        val lock =
+            lockRepository.find()
+                ?: return if (lockRepository.exists()) {
+                    MpmError.ProjectError
+                        .ConfigParseError(
+                            "mpm-lock.yaml が破損しています。手動で確認・修正してください（再現インストールのため自動再生成しません）。"
+                        ).left()
+                } else {
+                    MpmError.ProjectError
+                        .ConfigParseError(
+                            "mpm-lock.yaml が見つかりません。先に 'mpm install' を実行してロックファイルを生成してください。"
+                        ).left()
+                }
+
+        // プロジェクト（管理下プラグイン）を取得
+        val project = projectRepository.findOrError().getOrElse { return it.left() }
+        val mpmConfig = project.toDto()
+
+        // 依存順にインストールするためトポロジカルソートする
+        val sortedPlugins = mpmConfig.topologicalSortPlugins()
+
+        val installed = mutableListOf<PluginInstallInfo>()
+        val removed = mutableListOf<PluginRemovalInfo>()
+        val failed = mutableMapOf<String, String>()
+
+        for (pluginName in sortedPlugins) {
+            val expectedVersion = mpmConfig.plugins[pluginName] ?: continue
+            // unmanagedはロック対象外なのでスキップ
+            if (expectedVersion == "unmanaged") continue
+
+            // ロックにエントリが無い管理下プラグインはドリフトとして失敗扱いにする
+            val lockEntry = lock.plugins[pluginName]
+            if (lockEntry == null) {
+                failed[pluginName] = "ロックファイルにエントリがありません（mpm install で再生成してください）"
+                continue
+            }
+
+            // ロックに記録された正確なバージョンとsha256でインストールする
+            // （sha256を渡すことで、ダウンロードしたバイト列がロックと一致することを保証する）
+            installPluginWithVersion(
+                pluginName = pluginName,
+                expectedVersion = lockEntry.version.raw,
+                force = force,
+                skipIntegrity = skipIntegrity,
+                expectedSha256 = lockEntry.download.sha256
+            ).fold(
+                { failed[pluginName] = it },
+                { result ->
+                    installed.add(result.installed)
+                    result.removed?.let { removed.add(it) }
+                }
+            )
+        }
+
+        return BulkInstallResult(installed = installed, removed = removed, failed = failed).right()
     }
 
     /**
@@ -928,7 +1008,8 @@ class PluginUpdateServiceImpl :
         pluginName: String,
         expectedVersion: String,
         force: Boolean = false,
-        skipIntegrity: Boolean = false
+        skipIntegrity: Boolean = false,
+        expectedSha256: String? = null
     ): Either<String, InstallResult> {
         // リポジトリファイルを取得
         val repositoryFile =
@@ -1024,6 +1105,21 @@ class PluginUpdateServiceImpl :
 
         if (downloadedFile == null) {
             return "プラグインファイルのダウンロードに失敗しました。".left()
+        }
+
+        // frozenインストール時は、ロックファイルに記録されたsha256を最優先で照合する。
+        // リポジトリ側でアーティファクトが同じバージョン名のまま差し替えられていても検出でき、
+        // バイト単位の再現性（npm ci相当）を保証する。--skip-integrityでも省略しない（frozenの本質のため）。
+        if (expectedSha256 != null) {
+            val actualSha256 = integrityVerifier.computeSha256(downloadedFile)
+            if (!actualSha256.equals(expectedSha256, ignoreCase = true)) {
+                downloadedFile.delete()
+                return (
+                    "ロックファイルのハッシュと一致しません (sha256): " +
+                        "expected=$expectedSha256, actual=$actualSha256。" +
+                        "アーティファクトが差し替えられた可能性があります。"
+                ).left()
+            }
         }
 
         // ダウンロードしたtempファイルの整合性を検証する（ステージング前に実施）

--- a/paper/src/main/kotlin/party/morino/mpm/application/scheduler/UpdateSchedulerImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/scheduler/UpdateSchedulerImpl.kt
@@ -22,12 +22,14 @@ import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.scheduler.BukkitTask
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.PluginInfoService
 import party.morino.mpm.api.application.plugin.PluginUpdateService
 import party.morino.mpm.api.application.scheduler.UpdateScheduler
 import party.morino.mpm.api.domain.config.ConfigManager
 import party.morino.mpm.api.domain.config.model.ScheduleConfig
 import party.morino.mpm.api.domain.plugin.service.PluginMetadataManager
+import party.morino.mpm.utils.regenerateQuietly
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -47,6 +49,7 @@ class UpdateSchedulerImpl :
     private val updateService: PluginUpdateService by inject()
     private val infoService: PluginInfoService by inject()
     private val pluginMetadataManager: PluginMetadataManager by inject()
+    private val lockService: LockService by inject()
 
     // スケジューラータスクの参照（停止用）
     private var schedulerTask: BukkitTask? = null
@@ -344,6 +347,9 @@ class UpdateSchedulerImpl :
                                 "  ✓ ${result.pluginName}: ${result.oldVersion} -> ${result.newVersion}"
                             )
                         }
+                        // 実際にバージョンが更新された場合はロックファイルを再生成して追従させる
+                        // （スケジューラはコマンド層を経由しないため、ここで明示的に呼ぶ）
+                        lockService.regenerateQuietly(plugin.logger)
                     }
                     if (failed.isNotEmpty()) {
                         plugin.logger.warning("[Scheduled] Failed to update ${failed.size} plugin(s):")

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/persistence/LockRepositoryImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/persistence/LockRepositoryImpl.kt
@@ -1,0 +1,70 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.infrastructure.persistence
+
+import com.charleskorn.kaml.Yaml
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import party.morino.mpm.api.domain.config.PluginDirectory
+import party.morino.mpm.api.domain.project.lock.LockRepository
+import party.morino.mpm.api.domain.project.lock.MpmLock
+import java.io.File
+
+/**
+ * [LockRepository] の実装
+ *
+ * mpm-lock.yaml を mpm.json と同じルートディレクトリに読み書きする。
+ * 書き込みは一時ファイル + rename でアトミックに行い、クラッシュ時の破損を防ぐ。
+ */
+class LockRepositoryImpl :
+    LockRepository,
+    KoinComponent {
+    // Koinによる依存性注入
+    private val pluginDirectory: PluginDirectory by inject()
+
+    override suspend fun find(): MpmLock? {
+        val lockFile = getLockFile()
+        if (!lockFile.exists()) {
+            return null
+        }
+        return try {
+            val yamlString = lockFile.readText()
+            Yaml.default.decodeFromString(MpmLock.serializer(), yamlString)
+        } catch (e: Exception) {
+            // パース失敗時はnull（破損したロックは無視して再生成に委ねる）
+            null
+        }
+    }
+
+    override suspend fun save(lock: MpmLock) {
+        val lockFile = getLockFile()
+        val yamlString = Yaml.default.encodeToString(MpmLock.serializer(), lock)
+
+        // 一時ファイルへ書き込んでから rename（アトミック）で反映する
+        val tempFile = File(lockFile.parentFile, "${lockFile.name}.tmp")
+        tempFile.writeText(yamlString)
+        if (!tempFile.renameTo(lockFile)) {
+            tempFile.copyTo(lockFile, overwrite = true)
+            tempFile.delete()
+        }
+    }
+
+    override suspend fun exists(): Boolean = getLockFile().exists()
+
+    /**
+     * mpm-lock.yaml ファイルのパスを取得する（mpm.json と同じルートディレクトリ）
+     */
+    private fun getLockFile(): File {
+        val rootDir = pluginDirectory.getRootDirectory()
+        return File(rootDir, "mpm-lock.yaml")
+    }
+}

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/AddCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/AddCommand.kt
@@ -10,13 +10,16 @@
 package party.morino.mpm.ui.command.manage.lifecycle
 
 import org.bukkit.command.CommandSender
+import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.PluginLifecycleService
 import party.morino.mpm.api.domain.plugin.model.PluginName
 import party.morino.mpm.api.domain.plugin.model.VersionSpecifier
 import party.morino.mpm.api.model.plugin.RepositoryPlugin
 import party.morino.mpm.api.shared.error.MpmError
+import party.morino.mpm.utils.regenerateQuietly
 import revxrsal.commands.annotation.Command
 import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.annotation.Switch
@@ -32,6 +35,8 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
 class AddCommand : KoinComponent {
     // KoinによるDI
     private val lifecycleService: PluginLifecycleService by inject()
+    private val lockService: LockService by inject()
+    private val mpmPlugin: JavaPlugin by inject()
 
     /**
      * プラグインを管理対象に追加するコマンド（バージョン指定なし）
@@ -116,6 +121,9 @@ class AddCommand : KoinComponent {
                 )
             }
         )
+
+        // 追加・インストール後の実際の状態をロックファイルに反映する
+        lockService.regenerateQuietly(mpmPlugin.logger)
     }
 
     /**
@@ -190,6 +198,9 @@ class AddCommand : KoinComponent {
                     }
                 }
             )
+
+        // 追加・インストール後の実際の状態をロックファイルに反映する
+        lockService.regenerateQuietly(mpmPlugin.logger)
     }
 
     /**

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/InstallCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/InstallCommand.kt
@@ -10,9 +10,12 @@
 package party.morino.mpm.ui.command.manage.lifecycle
 
 import org.bukkit.command.CommandSender
+import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.PluginUpdateService
+import party.morino.mpm.utils.regenerateQuietly
 import revxrsal.commands.annotation.Command
 import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.annotation.Switch
@@ -28,21 +31,27 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
 class InstallCommand : KoinComponent {
     // KoinによるDI
     private val updateService: PluginUpdateService by inject()
+    private val lockService: LockService by inject()
+    private val plugin: JavaPlugin by inject()
 
     /**
      * mpm.jsonに定義されたプラグインを一括インストールするコマンド
      * @param sender コマンド送信者
+     * @param force api-version非互換でも強制インストールする
+     * @param skipIntegrity 整合性検証の不一致を無視する
+     * @param frozen mpm-lock.yamlに記録された正確なバージョンをインストールする（再現インストール）
      */
     @Subcommand("install")
     suspend fun install(
         sender: CommandSender,
         @Switch("force") force: Boolean = false,
-        @Switch("skip-integrity", shorthand = 'k') skipIntegrity: Boolean = false
+        @Switch("skip-integrity", shorthand = 'k') skipIntegrity: Boolean = false,
+        @Switch("frozen", shorthand = 'z') frozen: Boolean = false
     ) {
         sender.sendRichMessage("<gray>mpm.jsonを読み込んでいます...")
 
-        // PluginUpdateServiceを実行（force・skip-integrityフラグを伝播）
-        updateService.installAll(force, skipIntegrity).fold(
+        // PluginUpdateServiceを実行（force・skip-integrity・frozenフラグを伝播）
+        updateService.installAll(force, skipIntegrity, frozen).fold(
             // 失敗時の処理
             { error ->
                 sender.sendRichMessage("<red>${error.message}")
@@ -94,6 +103,12 @@ class InstallCommand : KoinComponent {
                 } else if (result.failed.isEmpty()) {
                     // すべて成功した場合
                     sender.sendRichMessage("<gray>変更を反映するには、サーバーを再起動してください。")
+                }
+
+                // frozenインストールはロックファイルどおりに導入するだけなので再生成しない。
+                // 通常インストール後は、実際の状態を反映するためロックファイルを再生成する
+                if (!frozen) {
+                    lockService.regenerateQuietly(plugin.logger)
                 }
             }
         )

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/RemoveCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/RemoveCommand.kt
@@ -10,11 +10,14 @@
 package party.morino.mpm.ui.command.manage.lifecycle
 
 import org.bukkit.command.CommandSender
+import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.PluginLifecycleService
 import party.morino.mpm.api.domain.plugin.model.PluginName
 import party.morino.mpm.api.model.plugin.InstalledPlugin
+import party.morino.mpm.utils.regenerateQuietly
 import revxrsal.commands.annotation.Command
 import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.annotation.Switch
@@ -30,6 +33,8 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
 class RemoveCommand : KoinComponent {
     // Koinによる依存性注入
     private val lifecycleService: PluginLifecycleService by inject()
+    private val lockService: LockService by inject()
+    private val mpmPlugin: JavaPlugin by inject()
 
     /**
      * プラグインを管理対象から除外するコマンド
@@ -56,6 +61,9 @@ class RemoveCommand : KoinComponent {
                 sender.sendRichMessage("<gray>ファイルも削除する場合は 'mpm uninstall $pluginId' を実行してください。</gray>")
             }
         )
+
+        // 管理対象からの除外後の状態をロックファイルに反映する
+        lockService.regenerateQuietly(mpmPlugin.logger)
     }
 
     /*

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/UninstallCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/UninstallCommand.kt
@@ -10,11 +10,14 @@
 package party.morino.mpm.ui.command.manage.lifecycle
 
 import org.bukkit.command.CommandSender
+import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.PluginLifecycleService
 import party.morino.mpm.api.domain.plugin.model.PluginName
 import party.morino.mpm.api.model.plugin.InstalledPlugin
+import party.morino.mpm.utils.regenerateQuietly
 import revxrsal.commands.annotation.Command
 import revxrsal.commands.annotation.Description
 import revxrsal.commands.annotation.Subcommand
@@ -30,6 +33,8 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
 class UninstallCommand : KoinComponent {
     // KoinによるDI
     private val lifecycleService: PluginLifecycleService by inject()
+    private val lockService: LockService by inject()
+    private val mpmPlugin: JavaPlugin by inject()
 
     @Subcommand("uninstall")
     @Description("指定されたプラグインをアンインストールします。")
@@ -50,5 +55,8 @@ class UninstallCommand : KoinComponent {
                 sender.sendRichMessage("<gray>変更を反映するには、サーバーを再起動してください。</gray>")
             }
         )
+
+        // アンインストール後の実際の状態をロックファイルに反映する
+        lockService.regenerateQuietly(mpmPlugin.logger)
     }
 }

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/UpdateCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/lifecycle/UpdateCommand.kt
@@ -10,13 +10,16 @@
 package party.morino.mpm.ui.command.manage.lifecycle
 
 import org.bukkit.command.CommandSender
+import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.PluginInfoService
 import party.morino.mpm.api.application.plugin.PluginUpdateService
 import party.morino.mpm.api.domain.plugin.model.PluginName
 import party.morino.mpm.api.domain.plugin.service.PluginMetadataManager
 import party.morino.mpm.api.model.plugin.InstalledPlugin
+import party.morino.mpm.utils.regenerateQuietly
 import revxrsal.commands.annotation.Command
 import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.annotation.Switch
@@ -34,6 +37,8 @@ class UpdateCommand : KoinComponent {
     private val updateService: PluginUpdateService by inject()
     private val infoService: PluginInfoService by inject()
     private val pluginMetadataManager: PluginMetadataManager by inject()
+    private val lockService: LockService by inject()
+    private val mpmPlugin: JavaPlugin by inject()
 
     /**
      * 新しいバージョンがあるプラグインを更新するコマンド
@@ -110,6 +115,9 @@ class UpdateCommand : KoinComponent {
                 }
             }
         )
+
+        // 更新後の実際の状態をロックファイルに反映する
+        lockService.regenerateQuietly(mpmPlugin.logger)
     }
 
     /**
@@ -151,6 +159,9 @@ class UpdateCommand : KoinComponent {
                 }
             }
         )
+
+        // 更新後の実際の状態をロックファイルに反映する
+        lockService.regenerateQuietly(mpmPlugin.logger)
     }
 
     /**

--- a/paper/src/main/kotlin/party/morino/mpm/utils/LockRegeneration.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/utils/LockRegeneration.kt
@@ -1,0 +1,28 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.utils
+
+import party.morino.mpm.api.application.lock.LockService
+import java.util.logging.Logger
+
+/**
+ * ロックファイル（mpm-lock.yaml）を再生成する。失敗しても例外は伝播させず警告ログのみ出す。
+ *
+ * install/update/add/remove/uninstall などの状態変更コマンドの成功後に呼び出し、
+ * ロックファイルを実際のインストール状態に追従させる。ロック生成の失敗は本処理の
+ * 成否に影響しないため、警告扱いとして握り潰す。
+ *
+ * @param logger 失敗時の警告出力に使用するロガー
+ */
+suspend fun LockService.regenerateQuietly(logger: Logger) {
+    regenerate().onLeft { error ->
+        logger.warning("ロックファイルの再生成に失敗しました: ${error.message}")
+    }
+}

--- a/paper/src/test/kotlin/party/morino/mpm/MpmTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/MpmTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
+import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.IntegrityVerifier
 import party.morino.mpm.api.application.plugin.PluginInfoService
 import party.morino.mpm.api.application.plugin.PluginLifecycleService
@@ -31,10 +32,12 @@ import party.morino.mpm.api.domain.config.model.ConfigData
 import party.morino.mpm.api.domain.dependency.DependencyAnalyzer
 import party.morino.mpm.api.domain.downloader.DownloaderRepository
 import party.morino.mpm.api.domain.plugin.service.PluginMetadataManager
+import party.morino.mpm.api.domain.project.lock.LockRepository
 import party.morino.mpm.api.domain.project.repository.ProjectRepository
 import party.morino.mpm.api.domain.repository.RepositoryManager
 import party.morino.mpm.api.domain.webhook.WebhookEventType
 import party.morino.mpm.api.domain.webhook.WebhookNotifier
+import party.morino.mpm.application.lock.LockServiceImpl
 import party.morino.mpm.application.plugin.IntegrityVerifierImpl
 import party.morino.mpm.application.plugin.PluginInfoServiceImpl
 import party.morino.mpm.application.plugin.PluginLifecycleServiceImpl
@@ -44,6 +47,7 @@ import party.morino.mpm.application.scheduler.UpdateSchedulerImpl
 import party.morino.mpm.application.search.PluginSearchServiceImpl
 import party.morino.mpm.infrastructure.dependency.DependencyAnalyzerImpl
 import party.morino.mpm.infrastructure.downloader.DownloaderRepositoryImpl
+import party.morino.mpm.infrastructure.persistence.LockRepositoryImpl
 import party.morino.mpm.infrastructure.persistence.ProjectRepositoryImpl
 import party.morino.mpm.infrastructure.plugin.service.PluginMetadataManagerImpl
 import party.morino.mpm.infrastructure.repository.RepositorySourceManagerFactory
@@ -104,6 +108,7 @@ class MpmTest :
                 // リポジトリの登録
                 single<DownloaderRepository> { DownloaderRepositoryImpl() }
                 single<ProjectRepository> { ProjectRepositoryImpl() }
+                single<LockRepository> { LockRepositoryImpl() }
 
                 // メタデータマネージャーの登録
                 single<PluginMetadataManager> { PluginMetadataManagerImpl() }
@@ -134,6 +139,7 @@ class MpmTest :
                 // 新しいApplication Serviceの登録
                 single<PluginInfoService> { PluginInfoServiceImpl() }
                 single<PluginSearchService> { PluginSearchServiceImpl() }
+                single<LockService> { LockServiceImpl() }
                 single<PluginLifecycleService> { PluginLifecycleServiceImpl() }
                 single<PluginUpdateService> { PluginUpdateServiceImpl() }
                 single<ProjectService> { ProjectServiceImpl() }

--- a/paper/src/test/kotlin/party/morino/mpm/application/lock/MpmLockSerializationTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/application/lock/MpmLockSerializationTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.application.lock
+
+import com.charleskorn.kaml.Yaml
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mpm.api.domain.downloader.model.RepositoryType
+import party.morino.mpm.api.domain.plugin.dto.MetadataDownloadInfoDto
+import party.morino.mpm.api.domain.plugin.dto.RepositoryInfo
+import party.morino.mpm.api.domain.plugin.dto.version.VersionDetailDto
+import party.morino.mpm.api.domain.project.lock.LockEntry
+import party.morino.mpm.api.domain.project.lock.MpmLock
+
+/**
+ * mpm-lock.yaml（MpmLock）のYAMLシリアライズが正しく往復することを検証する
+ */
+@DisplayName("MpmLock - YAML serialization")
+class MpmLockSerializationTest {
+    private fun sampleLock(): MpmLock =
+        MpmLock(
+            lockfileVersion = MpmLock.CURRENT_LOCKFILE_VERSION,
+            generatedAt = "2025-01-15T10:30:00Z",
+            plugins =
+                mapOf(
+                    "LuckPerms" to
+                        LockEntry(
+                            version = VersionDetailDto(raw = "v5.4.102", normalized = "5.4.102"),
+                            download =
+                                MetadataDownloadInfoDto(
+                                    downloadId = "v5.4.102",
+                                    fileName = "LuckPerms-Bukkit-5.4.102.jar",
+                                    url = "https://example.com/LuckPerms.jar",
+                                    sha256 = "abc123"
+                                ),
+                            repository = RepositoryInfo(type = RepositoryType.GITHUB, id = "LuckPerms/LuckPerms"),
+                            installedAt = "2025-01-15T10:30:00Z"
+                        )
+                )
+        )
+
+    @Test
+    @DisplayName("round-trips through YAML preserving all fields")
+    fun roundTrips() {
+        val lock = sampleLock()
+        val yaml = Yaml.default.encodeToString(MpmLock.serializer(), lock)
+        val parsed = Yaml.default.decodeFromString(MpmLock.serializer(), yaml)
+
+        assertEquals(lock, parsed)
+        // 主要フィールドがYAMLに含まれること
+        assertTrue(yaml.contains("lockfileVersion"))
+        assertTrue(yaml.contains("LuckPerms"))
+        assertTrue(yaml.contains("sha256"))
+    }
+}


### PR DESCRIPTION
Closes #354

> **Note:** このPRは #360（整合性検証）の上にスタックされています。ベースは `feat/integrity-verification` で、#360 のマージ後に main へ再ターゲットしてください。差分は lockfile のみです。

## 概要

実際にインストールされたプラグインの正確なバージョン・ダウンロード情報・sha256を記録する本物のロックファイル `mpm-lock.yaml` を実装しました。環境をまたいだ再現インストール（npmの `npm ci` 相当）を可能にします。ドキュメントで「未実装」とされていた機能です。

## 実装

- **モデル**: `MpmLock` / `LockEntry`（既存の version/download/repository DTOを再利用）
- **`LockRepository`**: `mpm-lock.yaml` を `mpm.json` と同じ場所にアトミック書き込み
- **`LockService.regenerate`**: 管理下プラグインのメタデータを集約してロックを再生成。`install`/`update`/`add`/`remove`/`uninstall` **およびスケジューラ自動更新**の後にフック
- **`mpm install --frozen`**: ロックに記録された正確なバージョンをインストールし、**ダウンロードしたアーティファクトを `lockEntry.download.sha256` で検証**（バイトドリフトや同一バージョン名での差し替えを検出）。リモート/保存済みハッシュとは独立に、ロックのハッシュを最優先で照合

## レビュー反映（マルチエージェント敵対的レビューで7件検出→5件修正）

- **frozenがロックのsha256を強制していなかった（HIGH）**: 新規環境ではバージョン文字列しかpinせず、差し替えを検出できなかった → ロックのsha256を最優先で照合するよう修正
- **スケジューラ自動更新がロックを再生成しない（HIGH）**: コマンド層をバイパスするため陳腐化 → スケジューラにフック追加
- **破損ロックが「見つからない」と誤報告（LOW）**: `exists()` で破損と不在を区別（破損時は自動再生成しない）
- **add成功→install失敗時の不完全エントリ（LOW）**: `fileName` null の未インストールプラグインを除外
- 判断: 逆ドリフト検出（ロックにあるがmpm.jsonに無い）はMVPで見送り（前方ドリフトは処理済み）

## テスト・ドキュメント

- `MpmLockSerializationTest`: YAML往復のテスト
- `task check` グリーン
- `docs/format/mpm-lock.mdx`（「未実装」を削除、`--frozen`とドリフト検出・自動生成を記載）