### PR TITLE
🩺 Add `mpm doctor` health check

### DIFF
--- a/api/src/main/kotlin/party/morino/mpm/api/application/health/DoctorReport.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/application/health/DoctorReport.kt
@@ -1,0 +1,54 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.api.application.health
+
+import party.morino.mpm.api.application.model.outdated.OutdatedInfo
+
+/**
+ * `mpm doctor` の診断結果
+ *
+ * 既存の各チェック（依存関係・整合性・更新・ロック・管理外）を集約したもの。
+ *
+ * @param missingDependencies プラグイン名 → 不足している必須依存プラグイン名のリスト
+ * @param hashMismatches 整合性検証でハッシュ不一致となったプラグイン名
+ * @param fileMissing メタデータはあるがJARファイルが見つからないプラグイン名
+ * @param unmanagedPlugins mpm管理外（orphan）のプラグイン名
+ * @param outdatedPlugins 更新が利用可能なプラグイン
+ * @param missingFromLock mpm.json管理下だがmpm-lock.yamlに記録がないプラグイン名（ロックのドリフト）
+ * @param staleLockEntries mpm-lock.yamlにあるがmpm.jsonの管理下にないプラグイン名（ロックのドリフト）
+ * @param warnings チェック中に発生した警告・エラーメッセージ
+ */
+data class DoctorReport(
+    val missingDependencies: Map<String, List<String>>,
+    val hashMismatches: List<String>,
+    val fileMissing: List<String>,
+    val unmanagedPlugins: List<String>,
+    val outdatedPlugins: List<OutdatedInfo>,
+    val missingFromLock: List<String>,
+    val staleLockEntries: List<String>,
+    val warnings: List<String>
+) {
+    /**
+     * 対処が必要な「実際の問題」が1つでもあるか
+     *
+     * 管理外プラグイン（[unmanagedPlugins]）・更新可能（[outdatedPlugins]）・[warnings] は判定に含めない。
+     * 特に [warnings] にはネットワークの一時障害などによるチェック失敗が含まれうるため、
+     * これを「異常」と扱うと健全なサーバーを誤って赤判定してしまう。判定は確定した問題のみに基づく。
+     */
+    val hasProblems: Boolean
+        get() =
+            missingDependencies.isNotEmpty() ||
+                hashMismatches.isNotEmpty() ||
+                fileMissing.isNotEmpty() ||
+                missingFromLock.isNotEmpty() ||
+                staleLockEntries.isNotEmpty()
+}

--- a/api/src/main/kotlin/party/morino/mpm/api/application/health/DoctorService.kt
+++ b/api/src/main/kotlin/party/morino/mpm/api/application/health/DoctorService.kt
@@ -1,0 +1,33 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.api.application.health
+
+import arrow.core.Either
+import party.morino.mpm.api.shared.error.MpmError
+
+/**
+ * サーバーのプラグイン管理状態を一括診断するサービス（`mpm doctor`）
+ *
+ * 依存関係・整合性・更新・ロック・管理外などの既存チェックを集約し、
+ * 1回の実行でサーバーの健全性を俯瞰できるようにする。
+ */
+interface DoctorService {
+    /**
+     * 各種チェックを実行して診断結果を返す
+     *
+     * 個別チェックの失敗は [DoctorReport.warnings] に集約し、可能な限り全体の診断を継続する。
+     * プロジェクトが未初期化などで診断自体が行えない場合のみエラーを返す。
+     *
+     * @return 診断結果
+     */
+    suspend fun diagnose(): Either<MpmError, DoctorReport>
+}

--- a/docs/content/docs/usage/doctor.mdx
+++ b/docs/content/docs/usage/doctor.mdx
@@ -1,0 +1,38 @@
+---
+title: 🩺 サーバーの健全性診断
+description: mpm doctor でプラグイン管理状態を一括診断する方法を説明します
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+`mpm doctor` は、サーバーのプラグイン管理状態を一括で診断するコマンドです。個別のコマンド（`mpm deps check`・`mpm verify`・`mpm outdated`・`mpm list`）を1つずつ実行しなくても、一度でサーバーの健全性を俯瞰できます。
+
+```bash
+mpm doctor
+```
+
+## 🔍 診断項目
+
+`mpm doctor` は次の項目をまとめて確認し、色分けして表示します。
+
+### 🔴 対処が必要な項目（異常）
+
+- **整合性エラー（ハッシュ不一致）** — インストール済み JAR が記録された sha256 と一致しません。破損・改竄の可能性があります（→ `mpm update <plugin>`）
+- **JARファイルが見つからない** — メタデータはあるが JAR が存在しません（→ `mpm install`）
+- **不足している必須依存** — 導入済みプラグインが必要とする依存が足りません（→ `mpm add <dep>`）
+- **ロックファイルのドリフト** — `mpm.json` と `mpm-lock.yaml` の内容がずれています（→ `mpm install`）
+
+### 🟡 情報（異常ではない）
+
+- **更新があります** — 新しいバージョンが利用可能です（→ `mpm update`）
+- **管理外のプラグイン** — mpm 管理下にない JAR があります（→ `mpm adopt`）
+
+<Callout type="info" title="読み取り専用">
+`mpm doctor` は診断のみを行い、プラグインのインストールや変更は一切行いません。表示されるヒントに従って、必要なコマンドを実行してください。
+</Callout>
+
+## 📚 関連ドキュメント
+
+- [🔒 整合性の検証](/docs/usage/integrity) - `mpm verify` の詳細
+- [依存関係コマンド](/docs/commands/dependency) - `mpm deps check` の詳細
+- [📌 ロックファイル](/docs/format/mpm-lock) - `mpm-lock.yaml` の仕様

--- a/docs/content/docs/usage/meta.json
+++ b/docs/content/docs/usage/meta.json
@@ -1,5 +1,5 @@
 {
     "title": "使い方",
     "description": "mpmの使い方を学びます",
-    "pages": ["getting-started", "install", "update", "discover", "integrity"]
+    "pages": ["getting-started", "install", "update", "discover", "integrity", "doctor"]
 }

--- a/docs/data/plugin.json
+++ b/docs/data/plugin.json
@@ -1,6 +1,13 @@
 {
     "commands": [
         {
+            "command": "mpm doctor",
+            "status": "newly",
+            "category": "plugin",
+            "section": "情報表示",
+            "description": "依存関係・整合性・更新・ロック・管理外を一括診断します"
+        },
+        {
             "command": "mpm verify",
             "status": "newly",
             "category": "plugin",

--- a/paper/src/main/kotlin/party/morino/mpm/Mpm.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/Mpm.kt
@@ -15,6 +15,7 @@ import org.koin.core.context.GlobalContext
 import org.koin.dsl.module
 import party.morino.mpm.api.MpmAPI
 import party.morino.mpm.api.application.dependency.DependencyService
+import party.morino.mpm.api.application.health.DoctorService
 import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.IntegrityVerifier
 import party.morino.mpm.api.application.plugin.PluginInfoService
@@ -38,6 +39,7 @@ import party.morino.mpm.api.domain.webhook.WebhookNotifier
 import party.morino.mpm.api.model.plugin.InstalledPlugin
 import party.morino.mpm.api.model.plugin.RepositoryPlugin
 import party.morino.mpm.application.dependency.DependencyServiceImpl
+import party.morino.mpm.application.health.DoctorServiceImpl
 import party.morino.mpm.application.lock.LockServiceImpl
 import party.morino.mpm.application.plugin.IntegrityVerifierImpl
 import party.morino.mpm.application.plugin.PluginInfoServiceImpl
@@ -66,6 +68,7 @@ import party.morino.mpm.ui.command.manage.control.InitCommand
 import party.morino.mpm.ui.command.manage.control.LockCommand
 import party.morino.mpm.ui.command.manage.control.PinCommand
 import party.morino.mpm.ui.command.manage.info.DependencyCommand
+import party.morino.mpm.ui.command.manage.info.DoctorCommand
 import party.morino.mpm.ui.command.manage.info.InfoCommand
 import party.morino.mpm.ui.command.manage.info.ListCommand
 import party.morino.mpm.ui.command.manage.info.OutdatedCommand
@@ -235,6 +238,8 @@ open class Mpm :
                 single<PluginSearchService> { PluginSearchServiceImpl() }
                 // ロックファイル（mpm-lock.yaml）管理
                 single<LockService> { LockServiceImpl() }
+                // サーバー健全性診断（mpm doctor）
+                single<DoctorService> { DoctorServiceImpl() }
                 // インストール前検証（APIバージョン互換性・依存関係）の共通ロジック
                 // PluginLifecycleServiceImplとPluginUpdateServiceImplの両方から利用される
                 single { PluginInstallValidator() }
@@ -287,6 +292,7 @@ open class Mpm :
         lamp.register(UpdateCommand())
         lamp.register(InfoCommand())
         lamp.register(SearchCommand())
+        lamp.register(DoctorCommand())
         lamp.register(VerifyCommand())
         lamp.register(VersionsCommand())
         lamp.register(RepositoryCommands())

--- a/paper/src/main/kotlin/party/morino/mpm/application/health/DoctorServiceImpl.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/application/health/DoctorServiceImpl.kt
@@ -1,0 +1,156 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain worldwide.
+ * This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.application.health
+
+import arrow.core.Either
+import arrow.core.getOrElse
+import arrow.core.right
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import party.morino.mpm.api.application.dependency.DependencyService
+import party.morino.mpm.api.application.health.DoctorReport
+import party.morino.mpm.api.application.health.DoctorService
+import party.morino.mpm.api.application.lock.LockService
+import party.morino.mpm.api.application.model.PluginFilter
+import party.morino.mpm.api.application.model.verify.VerifyStatus
+import party.morino.mpm.api.application.plugin.PluginInfoService
+import party.morino.mpm.api.domain.plugin.model.PluginSpec
+import party.morino.mpm.api.domain.project.repository.ProjectRepository
+import party.morino.mpm.api.shared.error.MpmError
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * [DoctorService] の実装
+ *
+ * 既存の各サービスをKoinで注入し、それらを組み合わせて診断レポートを生成する。
+ */
+class DoctorServiceImpl :
+    DoctorService,
+    KoinComponent {
+    // Koinによる依存性注入
+    private val projectRepository: ProjectRepository by inject()
+    private val infoService: PluginInfoService by inject()
+    private val dependencyService: DependencyService by inject()
+    private val lockService: LockService by inject()
+
+    override suspend fun diagnose(): Either<MpmError, DoctorReport> {
+        // プロジェクトが未初期化の場合は診断自体が行えないためエラーを返す
+        val project = projectRepository.findOrError().getOrElse { return Either.Left(it) }
+
+        val warnings = mutableListOf<String>()
+
+        // 管理下（Managed）のプラグイン名一覧
+        val managedNames =
+            project.plugins
+                .filterValues { it is PluginSpec.Managed }
+                .keys
+                .map { it.value }
+
+        // 各チェックは独立して実行し、1つの失敗（例外含む）が全体を止めないようにする。
+        // 失敗は warnings に集約して診断を継続する（warnings は「異常」判定には含めない）。
+
+        // 1. 不足している必須依存関係（プラグイン名 → 不足依存リスト）
+        val missingDependencies =
+            runDiagnostic("依存関係チェック", warnings, emptyMap()) {
+                dependencyService.checkMissingDependencies().filterValues { it.isNotEmpty() }
+            }
+
+        // 2. 整合性（ハッシュ不一致 / JAR欠落）
+        val verifyEntries =
+            runDiagnostic("整合性チェック", warnings, emptyList()) {
+                infoService.verifyInstalled().getOrElse {
+                    warnings.add("整合性チェックに失敗しました: ${it.message}")
+                    emptyList()
+                }
+            }
+        val hashMismatches = verifyEntries.filter { it.status == VerifyStatus.MISMATCH }.map { it.pluginName }
+        val fileMissing = verifyEntries.filter { it.status == VerifyStatus.FILE_MISSING }.map { it.pluginName }
+
+        // 3. 管理外（orphan）プラグイン
+        val unmanagedPlugins =
+            runDiagnostic("管理外プラグインの確認", warnings, emptyList()) {
+                infoService.list(PluginFilter.UNMANAGED).map { it.name.value }
+            }
+
+        // 4. 更新可能なプラグイン
+        val outdatedPlugins =
+            runDiagnostic("更新チェック", warnings, emptyList()) {
+                infoService.checkAllOutdated().fold(
+                    {
+                        warnings.add("更新チェックに失敗しました: ${it.message}")
+                        emptyList()
+                    },
+                    { result ->
+                        // 個別プラグインのチェックエラーは警告として記録する
+                        result.errors.forEach { warnings.add("${it.pluginName}: ${it.errorMessage}") }
+                        result.outdatedPlugins.filter { it.needsUpdate }
+                    }
+                )
+            }
+
+        // 5. ロックファイルのドリフト
+        val lock = lockService.find()
+        val missingFromLock: List<String>
+        val staleLockEntries: List<String>
+        if (lock == null) {
+            // ロック未生成。管理下プラグインがあるのに未生成なら警告する
+            missingFromLock = emptyList()
+            staleLockEntries = emptyList()
+            if (managedNames.isNotEmpty()) {
+                warnings.add("mpm-lock.yaml が未生成です。'mpm install' で生成できます。")
+            }
+        } else {
+            val lockKeys = lock.plugins.keys
+            // 管理下だがロックに無い（ドリフト）
+            missingFromLock = managedNames.filter { m -> lockKeys.none { it.equals(m, ignoreCase = true) } }
+            // ロックにあるが管理下でない（ドリフト）
+            staleLockEntries = lockKeys.filter { k -> managedNames.none { it.equals(k, ignoreCase = true) } }
+        }
+
+        return DoctorReport(
+            missingDependencies = missingDependencies,
+            hashMismatches = hashMismatches,
+            fileMissing = fileMissing,
+            unmanagedPlugins = unmanagedPlugins,
+            outdatedPlugins = outdatedPlugins,
+            missingFromLock = missingFromLock,
+            staleLockEntries = staleLockEntries,
+            warnings = warnings
+        ).right()
+    }
+
+    /**
+     * 1つの診断チェックを実行し、想定外の例外は警告に変換してデフォルト値を返す
+     *
+     * 1チェックの失敗が診断全体を止めないようにするための防御的ラッパー。
+     * コルーチンのキャンセルは握り潰さず伝播させる。
+     *
+     * @param label 失敗時のメッセージに使うチェック名
+     * @param warnings 失敗メッセージを追記する警告リスト
+     * @param default 失敗時に返すデフォルト値
+     * @param block 実行するチェック本体
+     */
+    private inline fun <T> runDiagnostic(
+        label: String,
+        warnings: MutableList<String>,
+        default: T,
+        block: () -> T
+    ): T =
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            warnings.add("$label に失敗しました: ${e.message}")
+            default
+        }
+}

--- a/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/info/DoctorCommand.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/ui/command/manage/info/DoctorCommand.kt
@@ -1,0 +1,137 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.ui.command.manage.info
+
+import org.bukkit.command.CommandSender
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import party.morino.mpm.api.application.health.DoctorReport
+import party.morino.mpm.api.application.health.DoctorService
+import party.morino.mpm.utils.escapeMiniMessage
+import revxrsal.commands.annotation.Command
+import revxrsal.commands.annotation.Description
+import revxrsal.commands.annotation.Subcommand
+import revxrsal.commands.bukkit.annotation.CommandPermission
+
+/**
+ * サーバー健全性診断コマンドのコントローラー
+ *
+ * mpm doctor - 依存関係・整合性・更新・ロック・管理外を一括診断して要約表示する
+ */
+@Command("mpm")
+@CommandPermission("mpm.command.list")
+class DoctorCommand : KoinComponent {
+    // Koinによる依存性注入
+    private val doctorService: DoctorService by inject()
+
+    /**
+     * サーバーのプラグイン管理状態を診断するコマンド
+     *
+     * @param sender コマンド送信者
+     */
+    @Subcommand("doctor")
+    @Description("プラグイン管理状態を一括診断します。")
+    suspend fun doctor(sender: CommandSender) {
+        sender.sendRichMessage("<gray>プラグイン管理状態を診断しています...</gray>")
+
+        doctorService.diagnose().fold(
+            { error ->
+                sender.sendRichMessage("<red>${error.message}</red>")
+            },
+            { report ->
+                render(sender, report)
+            }
+        )
+    }
+
+    /**
+     * 診断結果をセクションごとに色分けして表示する
+     */
+    private fun render(
+        sender: CommandSender,
+        report: DoctorReport
+    ) {
+        // プラグイン名・バージョン等はリポジトリ/plugin.yml由来の信頼できない文字列のため、
+        // MiniMessageタグとして解釈されないようエスケープして表示する
+        sender.sendRichMessage("<green>=== mpm doctor ===</green>")
+
+        // 🔴 ハッシュ不一致（改竄・破損の可能性）
+        if (report.hashMismatches.isNotEmpty()) {
+            sender.sendRichMessage("<red>✗ 整合性エラー (ハッシュ不一致):</red>")
+            report.hashMismatches.forEach { sender.sendRichMessage("<red>  - ${it.escapeMiniMessage()}</red>") }
+            sender.sendRichMessage("<gray>    → 'mpm update <plugin>' で再取得してください。</gray>")
+        }
+
+        // 🔴 JARファイル欠落
+        if (report.fileMissing.isNotEmpty()) {
+            sender.sendRichMessage("<red>✗ JARファイルが見つかりません:</red>")
+            report.fileMissing.forEach { sender.sendRichMessage("<red>  - ${it.escapeMiniMessage()}</red>") }
+            sender.sendRichMessage("<gray>    → 'mpm install' で再インストールしてください。</gray>")
+        }
+
+        // 🔴 不足している必須依存
+        if (report.missingDependencies.isNotEmpty()) {
+            sender.sendRichMessage("<red>✗ 不足している必須依存:</red>")
+            report.missingDependencies.forEach { (pluginName, missing) ->
+                val deps = missing.joinToString(", ") { it.escapeMiniMessage() }
+                sender.sendRichMessage("<red>  - ${pluginName.escapeMiniMessage()} → $deps</red>")
+            }
+            sender.sendRichMessage("<gray>    → 'mpm deps check' で確認、'mpm add <dep>' で追加してください。</gray>")
+        }
+
+        // 🟡 ロックファイルのドリフト
+        if (report.missingFromLock.isNotEmpty() || report.staleLockEntries.isNotEmpty()) {
+            sender.sendRichMessage("<yellow>⚠ ロックファイルのドリフト:</yellow>")
+            report.missingFromLock.forEach {
+                sender.sendRichMessage("<yellow>  - ${it.escapeMiniMessage()} (mpm.jsonにあるがロックに未記録)</yellow>")
+            }
+            report.staleLockEntries.forEach {
+                sender.sendRichMessage("<yellow>  - ${it.escapeMiniMessage()} (ロックにあるが管理下でない)</yellow>")
+            }
+            sender.sendRichMessage("<gray>    → 'mpm install' でロックを再生成してください。</gray>")
+        }
+
+        // 🟡 更新可能（情報）
+        if (report.outdatedPlugins.isNotEmpty()) {
+            sender.sendRichMessage("<yellow>⚠ 更新があります:</yellow>")
+            report.outdatedPlugins.forEach {
+                val name = it.pluginName.escapeMiniMessage()
+                val cur = it.currentVersion.escapeMiniMessage()
+                val latest = it.latestVersion.escapeMiniMessage()
+                sender.sendRichMessage("<yellow>  - $name: $cur → $latest</yellow>")
+            }
+            sender.sendRichMessage("<gray>    → 'mpm update' で更新できます。</gray>")
+        }
+
+        // 🟡 管理外プラグイン（情報）
+        if (report.unmanagedPlugins.isNotEmpty()) {
+            sender.sendRichMessage("<yellow>⚠ 管理外のプラグイン (${report.unmanagedPlugins.size}):</yellow>")
+            report.unmanagedPlugins.forEach { sender.sendRichMessage("<gray>  - ${it.escapeMiniMessage()}</gray>") }
+            sender.sendRichMessage("<gray>    → 'mpm adopt' で管理下に取り込めます。</gray>")
+        }
+
+        // ℹ チェックを完了できなかった項目（ネットワーク一時障害など。異常ではない）
+        if (report.warnings.isNotEmpty()) {
+            sender.sendRichMessage("<gray>ℹ 一部のチェックを完了できませんでした:</gray>")
+            report.warnings.forEach { sender.sendRichMessage("<gray>  - ${it.escapeMiniMessage()}</gray>") }
+        }
+
+        // サマリ
+        sender.sendRichMessage("<gray>${"=".repeat(30)}</gray>")
+        when {
+            report.hasProblems ->
+                sender.sendRichMessage("<red>対処が必要な項目があります。上記のヒントを参照してください。</red>")
+            report.outdatedPlugins.isEmpty() && report.unmanagedPlugins.isEmpty() && report.warnings.isEmpty() ->
+                sender.sendRichMessage("<green>✓ 問題は見つかりませんでした。すべて健全です。</green>")
+            else ->
+                sender.sendRichMessage("<green>✓ 異常はありません（更新・管理外・未完了チェックは情報です）。</green>")
+        }
+    }
+}

--- a/paper/src/test/kotlin/party/morino/mpm/MpmTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/MpmTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
+import party.morino.mpm.api.application.health.DoctorService
 import party.morino.mpm.api.application.lock.LockService
 import party.morino.mpm.api.application.plugin.IntegrityVerifier
 import party.morino.mpm.api.application.plugin.PluginInfoService
@@ -37,6 +38,7 @@ import party.morino.mpm.api.domain.project.repository.ProjectRepository
 import party.morino.mpm.api.domain.repository.RepositoryManager
 import party.morino.mpm.api.domain.webhook.WebhookEventType
 import party.morino.mpm.api.domain.webhook.WebhookNotifier
+import party.morino.mpm.application.health.DoctorServiceImpl
 import party.morino.mpm.application.lock.LockServiceImpl
 import party.morino.mpm.application.plugin.IntegrityVerifierImpl
 import party.morino.mpm.application.plugin.PluginInfoServiceImpl
@@ -140,6 +142,7 @@ class MpmTest :
                 single<PluginInfoService> { PluginInfoServiceImpl() }
                 single<PluginSearchService> { PluginSearchServiceImpl() }
                 single<LockService> { LockServiceImpl() }
+                single<DoctorService> { DoctorServiceImpl() }
                 single<PluginLifecycleService> { PluginLifecycleServiceImpl() }
                 single<PluginUpdateService> { PluginUpdateServiceImpl() }
                 single<ProjectService> { ProjectServiceImpl() }

--- a/paper/src/test/kotlin/party/morino/mpm/application/health/DoctorReportTest.kt
+++ b/paper/src/test/kotlin/party/morino/mpm/application/health/DoctorReportTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Written in 2023-2025 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package party.morino.mpm.application.health
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import party.morino.mpm.api.application.health.DoctorReport
+import party.morino.mpm.api.application.model.outdated.OutdatedInfo
+
+/**
+ * DoctorReport.hasProblems の分類（更新・管理外は情報扱い）を検証する
+ */
+@DisplayName("DoctorReport.hasProblems")
+class DoctorReportTest {
+    private fun report(
+        missingDependencies: Map<String, List<String>> = emptyMap(),
+        hashMismatches: List<String> = emptyList(),
+        fileMissing: List<String> = emptyList(),
+        unmanagedPlugins: List<String> = emptyList(),
+        outdatedPlugins: List<OutdatedInfo> = emptyList(),
+        missingFromLock: List<String> = emptyList(),
+        staleLockEntries: List<String> = emptyList(),
+        warnings: List<String> = emptyList()
+    ) = DoctorReport(
+        missingDependencies,
+        hashMismatches,
+        fileMissing,
+        unmanagedPlugins,
+        outdatedPlugins,
+        missingFromLock,
+        staleLockEntries,
+        warnings
+    )
+
+    @Test
+    @DisplayName("empty report has no problems")
+    fun emptyHasNoProblems() {
+        assertFalse(report().hasProblems)
+    }
+
+    @Test
+    @DisplayName("outdated and unmanaged alone are informational, not problems")
+    fun informationalOnlyIsNotProblem() {
+        val r =
+            report(
+                unmanagedPlugins = listOf("SomePlugin"),
+                outdatedPlugins = listOf(OutdatedInfo("Foo", "1.0", "1.1", needsUpdate = true))
+            )
+        assertFalse(r.hasProblems)
+    }
+
+    @Test
+    @DisplayName("hash mismatch counts as a problem")
+    fun hashMismatchIsProblem() {
+        assertTrue(report(hashMismatches = listOf("Foo")).hasProblems)
+    }
+
+    @Test
+    @DisplayName("lock drift counts as a problem")
+    fun lockDriftIsProblem() {
+        assertTrue(report(missingFromLock = listOf("Foo")).hasProblems)
+    }
+}


### PR DESCRIPTION
Closes #356

## 概要

依存関係・整合性・更新・ロック・管理外を**一括診断**する `mpm doctor` を追加しました。`mpm deps check` / `mpm verify` / `mpm outdated` / `mpm list` を個別に実行しなくても、一度でサーバーの健全性を俯瞰できます。

```bash
mpm doctor
```

## 実装

- **`DoctorService.diagnose()`** — 既存サービス（`DependencyService`・`PluginInfoService.verifyInstalled/list/checkAllOutdated`・`LockService`）を集約して `DoctorReport` を生成
- **`DoctorCommand`** — 🔴問題 / 🟡情報 / 🟢正常 をセクション分けして色分け表示し、対処ヒント（`mpm update`/`install`/`add`/`adopt`）を提示
- 診断項目: 不足必須依存 / ハッシュ不一致 / JAR欠落 / ロックドリフト（双方向）/ 更新可能 / 管理外プラグイン

## レビュー反映（マルチエージェント敵対的レビューで5件検出→3件修正）

- **一時的なチェック失敗が赤判定を誤発火（MEDIUM）**: ネットワーク一時障害等の警告が `hasProblems` を true にして健全なサーバーを「対処が必要」と誤表示 → **warnings を `hasProblems` から除外**し、「一部のチェックを完了できませんでした」という中立的な注記として表示
- **例外がコマンドのfoldをすり抜ける（LOW）**: 各チェックを防御的にラップし、想定外の例外は警告に変換（`CancellationException` は再throw）
- **MiniMessageタグ注入（LOW）**: プラグイン名・バージョンをエスケープしてから描画
- 判断: init後に追加したjarのorphan検出漏れ（LOW）は、mpmのinitスナップショットモデルと一貫のため許容

## テスト・ドキュメント

- `DoctorReportTest`: hasProblems の分類（更新・管理外・警告は情報扱い）4ケース
- `task check` グリーン
- `docs/usage/doctor.mdx`（新規）、`docs/data/plugin.json`