### PR TITLE
⬆️ Migrate MineAuth integration to v2 plugin API

### DIFF
--- a/docs/content/docs/api/http/mineauth.mdx
+++ b/docs/content/docs/api/http/mineauth.mdx
@@ -13,25 +13,35 @@ mpm自体の動作には一切影響しません。
 
 ## 有効化の仕組み
 
-サーバー起動時、mpmは以下の順序でMineAuthとの連携を試みます。
+mpmはMineAuthの`MineAuthApi`（v2）に対応しています。サーバー起動時、mpmは以下の順序でMineAuthとの連携を試みます。
 
 1. `MineAuth` プラグインがサーバーに存在するか確認する
-2. 存在する場合、`MineAuthAPI` を実装しているか確認する
-3. 両方を満たす場合のみ、mpmのハンドラーをMineAuthに登録する
+2. 存在する場合、Bukkitの`ServicesManager`経由で`MineAuthApi`インスタンスを取得する
+3. 取得できた場合のみ、mpmのハンドラーを`mpm`名前空間で登録する
 
-いずれかの条件を満たさない場合や、バージョン不整合などで例外が発生した場合は、警告ログを出力したうえで連携を無効化し、
-mpm本体の起動は継続します。
+登録はall-or-nothingで行われます。いずれかのエンドポイントが検証に失敗した場合は何もマウントされず、
+検証エラーの一覧を含む警告ログを出力したうえで連携を無効化します。いずれの場合もmpm本体の起動は継続します。
+なお、登録されたエンドポイントはmpmプラグインの無効化時にMineAuth側で自動的に登録解除されます。
 
 | 状態 | ログ | 結果 |
 | --- | --- | --- |
 | MineAuth未導入 | `MineAuth not found - HTTP API integration disabled` | 連携なしで起動 |
-| 互換性のないMineAuth | `MineAuth found but doesn't implement MineAuthAPI - HTTP API integration disabled` | 連携なしで起動 |
-| 連携成功 | `MineAuth integration enabled - endpoints registered at /api/v1/plugins/mpm/` | エンドポイント有効化 |
+| APIサービス取得不可 | `MineAuth found but MineAuthApi service is unavailable - HTTP API integration disabled` | 連携なしで起動 |
+| 登録検証エラー | `MineAuth endpoint registration failed - HTTP API will be unavailable: ...` | 連携なしで起動 |
+| 連携成功 | `MineAuth integration enabled - N endpoints registered under /api/v1/plugins/mpm/` | エンドポイント有効化 |
 
 ## 認証・権限
 
-登録されるすべてのエンドポイントは、MineAuthの権限 `mpm.api` によって保護されます。
-この権限を持つユーザー、またはMineAuthのservice accountからのみアクセスできます。
+登録されるすべてのエンドポイントは`@Authenticated`により認証必須で、権限 `mpm.api` によって保護されます。
+
+- **ユーザートークン**: 権限 `mpm.api` を持つプレイヤーのトークンからのみアクセスできます。
+- **サービストークン**: 各エンドポイントが `callers` にサービストークンを明示的に許可しているためアクセスできます。サービストークンは管理者が発行する信頼された資格情報であり、`mpm.api` 権限の評価対象外です。
+
+:::info
+MineAuth v2では、旧APIにあった「サービストークンによる権限の暗黙的なバイパス」は廃止され、
+エンドポイントごとに `callers` で明示的に許可する方式に変わりました。mpmの全エンドポイントは
+ユーザートークン・サービストークンの両方を許可するよう設定されています。
+:::
 
 ## エンドポイント一覧
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
-mineauth-api = { group = "party.morino", name = "mineauth-api", version = "0.2.30" }
+mineauth-api = { group = "party.morino", name = "mineauth-api", version = "0.2.33" }
 
 commons-io = { group = "commons-io", name = "commons-io", version.ref = "commonsIo" }
 snakeyaml = { group = "org.yaml", name = "snakeyaml", version = "2.6" }

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/mineauth/MineAuthIntegration.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/mineauth/MineAuthIntegration.kt
@@ -10,13 +10,18 @@
 package party.morino.mpm.infrastructure.mineauth
 
 import org.bukkit.plugin.java.JavaPlugin
-import party.morino.mineauth.api.MineAuthAPI
+import party.morino.mineauth.api.EndpointRegistrationException
+import party.morino.mineauth.api.MineAuthApi
 
 /**
  * MineAuth との連携を管理するクラス
  *
  * MineAuth プラグインが存在する場合のみ HTTP エンドポイントを登録する。
  * 存在しない場合は何もしない（soft dependency として扱う）。
+ *
+ * MineAuth v2 API（[MineAuthApi]）に対応する。
+ * API インスタンスは Bukkit の ServicesManager 経由で取得し、
+ * エンドポイントは all-or-nothing で登録される（1つでも検証に失敗すれば何もマウントされない）。
  */
 class MineAuthIntegration(
     private val plugin: JavaPlugin
@@ -24,36 +29,45 @@ class MineAuthIntegration(
     /**
      * MineAuth が利用可能か確認してエンドポイントを登録する
      *
-     * MineAuth が存在しない場合は警告を出さずにスキップする。
+     * MineAuth が存在しない場合は情報ログのみ出力してスキップする。
      */
     fun setup() {
         // NoClassDefFoundError など Throwable も含めて全体を保護する。
-        // 古いバージョンや互換性のない MineAuth が存在する場合に as? キャストで
-        // クラスロードが失敗する可能性があるため、try-catch は最外側に配置する。
+        // MineAuth 未導入時は compileOnly の API クラスが解決できず
+        // NoClassDefFoundError が発生しうるため、try-catch は最外側に配置する。
         try {
-            val mineAuthPlugin = plugin.server.pluginManager.getPlugin("MineAuth")
-            if (mineAuthPlugin == null) {
+            // MineAuth プラグインの存在確認。
+            // API クラスに触れずに soft dependency を判定することで、
+            // 未導入時に NoClassDefFoundError を発生させず info ログで済ませる。
+            if (plugin.server.pluginManager.getPlugin("MineAuth") == null) {
                 plugin.logger.info("MineAuth not found - HTTP API integration disabled")
                 return
             }
 
-            // 互換性のない MineAuth の場合 ClassCastException / NoClassDefFoundError が発生しうる
-            val mineAuthApi = mineAuthPlugin as? MineAuthAPI
-            if (mineAuthApi == null) {
+            // ServicesManager 経由で MineAuthApi を取得する（v2 API のエントリーポイント）
+            val api = MineAuthApi.get(plugin.server)
+            if (api == null) {
                 plugin.logger.warning(
-                    "MineAuth found but doesn't implement MineAuthAPI - HTTP API integration disabled"
+                    "MineAuth found but MineAuthApi service is unavailable - HTTP API integration disabled"
                 )
                 return
             }
 
-            // mpm のエンドポイントを MineAuth に登録する
-            // 登録後は /api/v1/plugins/mpm/ 配下でアクセス可能になる
-            mineAuthApi
-                .createHandler(plugin)
-                .register(MpmPluginHandler())
-            plugin.logger.info("MineAuth integration enabled - endpoints registered at /api/v1/plugins/mpm/")
+            // mpm 名前空間でハンドラーを登録する（/api/v1/plugins/mpm/ 配下にマウントされる）。
+            // 登録は all-or-nothing で、失敗時は EndpointRegistrationException がスローされる。
+            // プラグイン無効化時には MineAuth 側で自動的に登録解除される。
+            val registration = api.register(plugin, "mpm", MpmPluginHandler())
+            plugin.logger.info(
+                "MineAuth integration enabled - " +
+                    "${registration.endpoints.size} endpoints registered under ${registration.basePath}/"
+            )
+        } catch (e: EndpointRegistrationException) {
+            // 登録は all-or-nothing のため、検証エラーの全リストをまとめて出力する
+            plugin.logger.warning(
+                "MineAuth endpoint registration failed - HTTP API will be unavailable:\n${e.message}"
+            )
         } catch (e: Throwable) {
-            // NoClassDefFoundError、ClassCastException など を含む全エラーをキャッチ
+            // NoClassDefFoundError（互換性のない MineAuth など）を含む全エラーをキャッチ
             plugin.logger.warning(
                 "MineAuth integration failed (${e::class.simpleName}): ${e.message} - HTTP API will be unavailable"
             )

--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/mineauth/MpmPluginHandler.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/mineauth/MpmPluginHandler.kt
@@ -11,11 +11,12 @@ package party.morino.mpm.infrastructure.mineauth
 
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import party.morino.mineauth.api.annotations.GetMapping
-import party.morino.mineauth.api.annotations.PathParam
-import party.morino.mineauth.api.annotations.Permission
-import party.morino.mineauth.api.annotations.PostMapping
-import party.morino.mineauth.api.annotations.QueryParams
+import party.morino.mineauth.api.CallerType
+import party.morino.mineauth.api.annotations.Authenticated
+import party.morino.mineauth.api.annotations.Get
+import party.morino.mineauth.api.annotations.Path
+import party.morino.mineauth.api.annotations.Post
+import party.morino.mineauth.api.annotations.QueryMap
 import party.morino.mineauth.api.http.HttpError
 import party.morino.mineauth.api.http.HttpStatus
 import party.morino.mpm.api.application.model.PluginFilter
@@ -61,11 +62,14 @@ private fun MpmError.toHttpStatus(): HttpStatus =
 /**
  * mpm の MineAuth HTTP ハンドラー
  *
- * MineAuth の RegisterHandler API を通じて登録される。
+ * MineAuth v2 API（[party.morino.mineauth.api.MineAuthApi.register]）を通じて登録される。
  * エンドポイントは /api/v1/plugins/mpm/ 配下にマウントされる。
- * @Permission("mpm.api") によって保護され、service account は自動的にバイパスできる。
+ *
+ * MineAuth v2 では全エンドポイントがアクセス宣言を必須とするため、各メソッドに
+ * `@Authenticated(permission = "mpm.api", callers = [USER, SERVICE])` を付与する。
+ * permission はユーザートークンにのみ評価され、サービストークンは明示的に
+ * `callers` へ含めることで許可される（旧 API の service account バイパス相当の挙動を維持する）。
  */
-@Permission("mpm.api")
 class MpmPluginHandler : KoinComponent {
     // KoinによるDI
     private val pluginInfoService: PluginInfoService by inject()
@@ -78,7 +82,8 @@ class MpmPluginHandler : KoinComponent {
      *
      * @return 管理中プラグインの一覧
      */
-    @GetMapping("/plugins")
+    @Get("/plugins")
+    @Authenticated(permission = "mpm.api", callers = [CallerType.USER, CallerType.SERVICE])
     suspend fun listPlugins(): List<PluginSummaryResponse> {
         val plugins = pluginInfoService.list(PluginFilter.ALL)
         return plugins.map { PluginSummaryResponse.from(it) }
@@ -90,7 +95,8 @@ class MpmPluginHandler : KoinComponent {
      *
      * @return 更新可能なプラグインの一覧
      */
-    @GetMapping("/plugins/outdated")
+    @Get("/plugins/outdated")
+    @Authenticated(permission = "mpm.api", callers = [CallerType.USER, CallerType.SERVICE])
     suspend fun listOutdatedPlugins(): List<OutdatedPluginResponse> {
         val result =
             pluginInfoService.checkAllOutdated().fold(
@@ -110,9 +116,10 @@ class MpmPluginHandler : KoinComponent {
      * @param params クエリパラメータ（force=true で api-version 非互換でも強制更新）
      * @return 各プラグインの更新結果一覧
      */
-    @PostMapping("/plugins/update")
+    @Post("/plugins/update")
+    @Authenticated(permission = "mpm.api", callers = [CallerType.USER, CallerType.SERVICE])
     suspend fun updateAllPlugins(
-        @QueryParams params: Map<String, String>
+        @QueryMap params: Map<String, String>
     ): List<UpdateResult> {
         val force = params["force"]?.parseBooleanParam() ?: false
         return pluginUpdateService.update(force = force).fold(
@@ -131,10 +138,11 @@ class MpmPluginHandler : KoinComponent {
      * @param params クエリパラメータ（force=true で強制更新）
      * @return 更新結果
      */
-    @PostMapping("/plugins/{name}/update")
+    @Post("/plugins/{name}/update")
+    @Authenticated(permission = "mpm.api", callers = [CallerType.USER, CallerType.SERVICE])
     suspend fun updatePlugin(
-        @PathParam("name") name: String,
-        @QueryParams params: Map<String, String>
+        @Path("name") name: String,
+        @QueryMap params: Map<String, String>
     ): UpdateResult {
         val force = params["force"]?.parseBooleanParam() ?: false
         return pluginUpdateService.update(PluginName(name), force = force).fold(
@@ -154,10 +162,11 @@ class MpmPluginHandler : KoinComponent {
      * @param params クエリパラメータ（force=true で api-version 非互換でも強制インストール）
      * @return インストール結果
      */
-    @PostMapping("/plugins/{name}/install")
+    @Post("/plugins/{name}/install")
+    @Authenticated(permission = "mpm.api", callers = [CallerType.USER, CallerType.SERVICE])
     suspend fun installPlugin(
-        @PathParam("name") name: String,
-        @QueryParams params: Map<String, String>
+        @Path("name") name: String,
+        @QueryMap params: Map<String, String>
     ): InstallResultResponse {
         val force = params["force"]?.parseBooleanParam() ?: false
         val result =
@@ -177,9 +186,10 @@ class MpmPluginHandler : KoinComponent {
      * @param name アンインストール対象のプラグイン名
      * @return アンインストール結果
      */
-    @PostMapping("/plugins/{name}/uninstall")
+    @Post("/plugins/{name}/uninstall")
+    @Authenticated(permission = "mpm.api", callers = [CallerType.USER, CallerType.SERVICE])
     suspend fun uninstallPlugin(
-        @PathParam("name") name: String
+        @Path("name") name: String
     ): UninstallResponse {
         pluginLifecycleService.uninstall(PluginName(name)).fold(
             ifLeft = { error ->


### PR DESCRIPTION
## Summary

MineAuth v0.2.32 shipped a breaking redesign of its plugin API (morinoparty/MineAuth#371). This updates mpm's MineAuth HTTP integration to the new v2 API.

## Changes

- **Dependency**: `mineauth-api` `0.2.30` → `0.2.33`
- **`MineAuthIntegration`**: acquire the API via Bukkit `ServicesManager` (`MineAuthApi.get(server)`) instead of casting the plugin instance. `getPlugin("MineAuth")` is probed first so an absent MineAuth logs at info level without touching the compileOnly API classes (avoids `NoClassDefFoundError`). Registers under an explicit `"mpm"` namespace with the all-or-nothing `register()`, surfacing `EndpointRegistrationException` details on failure.
- **`MpmPluginHandler`**: `@GetMapping/@PostMapping/@PathParam/@QueryParams` → `@Get/@Post/@Path/@QueryMap`. Every endpoint now declares access explicitly with `@Authenticated(permission = "mpm.api", callers = [CallerType.USER, CallerType.SERVICE])`.
- **Docs**: updated the activation flow, log-message table, and auth model in `docs/.../api/http/mineauth.mdx`.

## Behavior preservation

v2 made the service-token permission bypass opt-in. Explicitly allowing `CallerType.SERVICE` preserves the old class-level `@Permission("mpm.api")` behavior: USER tokens still require `mpm.api`, SERVICE tokens still bypass the permission check. No endpoint became public or lost protection. Endpoint URLs are unchanged (`/api/v1/plugins/mpm/...`).

## Verification

- `task check` passes (compiles against v2 symbols that do not exist in 0.2.30, proving the build resolves the new API).
- No leftover references to old API symbols.
- All 6 endpoints reviewed against the 14 v2 registration-validation rules.

> [!NOTE]
> codex review was unavailable (usage-limited); reviewed via the advisor tool instead.