### PR TITLE
🐛 Fix soft-dependency crash when MineAuth is absent

### DIFF
--- a/paper/src/main/kotlin/party/morino/mpm/infrastructure/mineauth/MineAuthIntegration.kt
+++ b/paper/src/main/kotlin/party/morino/mpm/infrastructure/mineauth/MineAuthIntegration.kt
@@ -10,7 +10,6 @@
 package party.morino.mpm.infrastructure.mineauth
 
 import org.bukkit.plugin.java.JavaPlugin
-import party.morino.mineauth.api.EndpointRegistrationException
 import party.morino.mineauth.api.MineAuthApi
 
 /**
@@ -33,8 +32,14 @@ class MineAuthIntegration(
      */
     fun setup() {
         // NoClassDefFoundError など Throwable も含めて全体を保護する。
-        // MineAuth 未導入時は compileOnly の API クラスが解決できず
-        // NoClassDefFoundError が発生しうるため、try-catch は最外側に配置する。
+        // MineAuth 未導入時は compileOnly の API クラス（EndpointRegistrationException 等）が
+        // 解決できず NoClassDefFoundError が発生しうる。
+        //
+        // 重要: MineAuth 由来の型は「本体で遅延解決される」参照だけに留め、catch 節の例外型には
+        // 使わないこと。catch 節の例外型はメソッド検証時（＝呼び出した瞬間）に即ロードされるため、
+        // MineAuth が無い環境では setup() の呼び出し自体が catch(Throwable) の外側で
+        // NoClassDefFoundError を投げ、soft dependency の保護をすり抜けてしまう。
+        // そのため EndpointRegistrationException は個別 catch せず catch(Throwable) でまとめて扱う。
         try {
             // MineAuth プラグインの存在確認。
             // API クラスに触れずに soft dependency を判定することで、
@@ -61,13 +66,10 @@ class MineAuthIntegration(
                 "MineAuth integration enabled - " +
                     "${registration.endpoints.size} endpoints registered under ${registration.basePath}/"
             )
-        } catch (e: EndpointRegistrationException) {
-            // 登録は all-or-nothing のため、検証エラーの全リストをまとめて出力する
-            plugin.logger.warning(
-                "MineAuth endpoint registration failed - HTTP API will be unavailable:\n${e.message}"
-            )
         } catch (e: Throwable) {
-            // NoClassDefFoundError（互換性のない MineAuth など）を含む全エラーをキャッチ
+            // 登録検証エラー（EndpointRegistrationException。message に全検証エラーを含む）や
+            // NoClassDefFoundError（互換性のない MineAuth など）を含む全エラーをキャッチする。
+            // EndpointRegistrationException を個別 catch しないのは上記コメントの理由による。
             plugin.logger.warning(
                 "MineAuth integration failed (${e::class.simpleName}): ${e.message} - HTTP API will be unavailable"
             )


### PR DESCRIPTION
## Problem

The whole `paper` test suite started failing after #367/#366/#365 merged:

```
java.lang.NoClassDefFoundError: party/morino/mineauth/api/EndpointRegistrationException
	at party.morino.mpm.Mpm.onEnable(Mpm.kt:132)
	... MockBukkit.load ... MpmTest.setupKoin
```

**This is not just a test issue — it breaks production.** mpm would fail to enable on any server that does not have MineAuth installed.

## Root cause

The v2 migration (#367) added `catch (e: EndpointRegistrationException)` to `MineAuthIntegration.setup()`. Catch-clause exception types are resolved during **method verification** (i.e. when the method is invoked), *before* the body runs. `mineauth-api` is `compileOnly`, so when its classes are absent (MineAuth not installed, or the JUnit/MockBukkit runtime), invoking `setup()` throws `NoClassDefFoundError` **at the call site in `Mpm.onEnable()`**, outside `setup()`'s own `catch (Throwable)`. The soft-dependency guard is bypassed entirely.

The old v1 code was safe because every optional MineAuth type was referenced only in the method **body** (resolved lazily, inside the `try`).

## Fix

Keep all MineAuth-derived types in the `try` body (resolved lazily, after the `getPlugin("MineAuth")` presence check) and catch only `Throwable`. `EndpointRegistrationException.message` already carries the full validation-error list, so registration failures are still logged via the generic handler. Added a comment documenting the catch-clause pitfall so it is not reintroduced.

## Verification

- All **124** paper tests pass (`failures=0 errors=0`); previously the entire suite errored.
- `task check` green.
- Behavior when MineAuth is present is unchanged; when absent, mpm now enables cleanly and logs `MineAuth not found - HTTP API integration disabled`.